### PR TITLE
feat: read credentials.ini from XDG_CONFIG_HOME (or os equivalents) in addition to bin directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "block2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +139,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "discord-rich-presence"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +177,7 @@ version = "2.2.3"
 dependencies = [
  "chrono",
  "configparser",
+ "dirs",
  "discord-rich-presence",
  "serde",
  "ureq",
@@ -294,6 +322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -765,6 +820,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -785,6 +849,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -810,6 +889,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
@@ -819,6 +904,12 @@ name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -834,6 +925,12 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
@@ -843,6 +940,12 @@ name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -858,6 +961,12 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
@@ -870,6 +979,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
@@ -879,6 +994,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ configparser = { version = "3.1.0", features = ["indexmap"] }
 serde = { version = "1.0.204", features = ["derive"] }
 chrono = "0.4.38"
 webbrowser = "1.0.1"
+dirs = "5.0.1"
 
 [profile.release]
 strip = "debuginfo"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Plex Rich Presence alternatives:
 |--------|-----|-------|
 |Linux|`$XDG_CONFIG_HOME`/discrakt or `$HOME`/.config/discrakt|/home/alice/.config/discrakt/credentials.ini|
 |macOS|`$HOME`/Library/Application Support/discrakt|/Users/Alice/Library/Application Support/discrakt/credentials.ini|
-|Windows|`%LOCALAPPDATA%`\discrakt|C:\Users\Alice\AppData\Roaming\discrakt\credentials.ini|
+|Windows|`%APPDATA%`\discrakt|C:\Users\Alice\AppData\Roaming\discrakt\credentials.ini|
 
 ## Running executables
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Plex Rich Presence alternatives:
 |--------|-----|-------|
 |Linux|`$XDG_CONFIG_HOME`/discrakt or `$HOME`/.config/discrakt|/home/alice/.config/discrakt/credentials.ini|
 |macOS|`$HOME`/Library/Application Support/discrakt|/Users/Alice/Library/Application Support/discrakt/credentials.ini|
-|Windows|`%LOCALAPPDATA%`\discrakt|C:\Users\Alice\AppData\Local\discrakt\credentials.ini|
+|Windows|`%LOCALAPPDATA%`\discrakt|C:\Users\Alice\AppData\Roaming\discrakt\credentials.ini|
 
 ## Running executables
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Plex Rich Presence alternatives:
 *P.S.* Discord needs to be running on the machine Discrakt is running on.
 *P.P.S.* Place the `credentials.ini` file in the same directory as the executable.
 
+*P.P.P.S.* If you want to store the configuration in a common location, the `credentials.ini` can also be stored in:
+
+|Operating System|Location|Example|
+|--------|-----|-------|
+|Linux|`$XDG_CONFIG_HOME`/discrakt or `$HOME`/.config/discrakt|/home/alice/.config/discrakt/credentials.ini|
+|macOS|`$HOME`/Library/Application Support/discrakt|/Users/Alice/Library/Application Support/discrakt/credentials.ini|
+|Windows|`%LOCALAPPDATA%`\discrakt|C:\Users\Alice\AppData\Local\discrakt\credentials.ini|
+
 ## Running executables
 
 Running the executables is as easy as clicking the provided executables in the latest [release](https://github.com/afonsojramos/discrakt/releases). That's it!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,7 +142,7 @@ impl Env {
 }
 
 fn find_config_file() -> Option<PathBuf> {
-    let config_path = dirs::config_local_dir().unwrap().join("discrakt");
+    let config_path = dirs::config_dir().unwrap().join("discrakt");
     let mut exe_path = env::current_exe().unwrap();
     exe_path.pop();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,11 +142,11 @@ impl Env {
 }
 
 fn find_config_file() -> Option<PathBuf> {
-    let xdg_config_path = dirs::config_local_dir().unwrap().join("discrakt");
+    let config_path = dirs::config_local_dir().unwrap().join("discrakt");
     let mut exe_path = env::current_exe().unwrap();
     exe_path.pop();
 
-    let locations = vec![xdg_config_path, exe_path];
+    let locations = vec![config_path, exe_path];
 
     for location in &locations {
         let config_file = location.join("credentials.ini");


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗
Keep it short and sweet 🙌
-->

## 📑 Description

Maybe it's just linux people but I'm not a fan of having configuration files in the same folder as the binary (as I installed in ~/.local/bin)

Each OS has its own 'assigned' configuration directory:
|Platform|Value|Example|
|--------|-----|-------|
|Linux|`$XDG_CONFIG_HOME` or `$HOME`/.config|/home/alice/.config|
|macOS|`$HOME`/Library/Application Support|/Users/Alice/Library/Application Support|
|Windows|`{FOLDERID_LocalAppData}`|C:\Users\Alice\AppData\Local|

Ideally the credentials.ini file would be managed by the cli tool and placed there, rather than the user doing it themselves, however I thought I'd keep the changes small.

I don't have a mac to test this on and haven't on windows yet (just linux)
> NOTE: This does introduce a small new dependency [`dirs`](https://crates.io/crates/dirs), not sure how you'd feel about that - there's probably other ways to do it, but this seemed to be the 'easiest'

## ✅ Checks
- [x] **code:** My pull request adheres to the code style of this project
- [x] **docs:** Added / updated
- [x] **tests:** All the tests have passed
> Note: all 0 tests passed via `cargo test`
## ℹ Additional Information

Note: I've only done a tiny bit of rust, apologies for any noobiness :)

Showing the error with multiple locations
```bash
$ cargo run --release
   Compiling discrakt v2.2.3 (/home/rob/Code/github.com/RobBrazier/discrakt)
    Finished `release` profile [optimized] target(s) in 1.52s
     Running `target/release/discrakt`
Could not find credentials.ini in ["/home/rob/.config/discrakt", "/home/rob/Code/github.com/RobBrazier/discrakt/target/release"]
thread 'main' panicked at src/utils.rs:171:28:
Could not find credentials.ini
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Reading credentialas from bin directory (current behaviour)
```bash
$ ls target/release/credentials.ini
/home/rob/Code/github.com/RobBrazier/discrakt/target/release/credentials.ini
$ ls ~/.config/discrakt/credentials.ini
ls: cannot access '/home/rob/.config/discrakt/credentials.ini': No such file or directory
$ cargo run --release
    Finished `release` profile [optimized] target(s) in 0.02s
     Running `target/release/discrakt`
2024-08-11T16:14:49Z : One Piece - S4E109 - The Key to a Great Comeback Escape! The Wax-Wax Ball! | 7.64%
```

Reading credentials from XDG_CONFIG_HOME and equivalents
```bash
$ ls target/release/credentials.ini
ls: cannot access 'target/release/credentials.ini': No such file or directory
$ ls ~/.config/discrakt/credentials.ini
/home/rob/.config/discrakt/credentials.ini
$ cargo run --release
    Finished `release` profile [optimized] target(s) in 0.02s
     Running `target/release/discrakt`
2024-08-11T16:18:20Z : One Piece - S4E109 - The Key to a Great Comeback Escape! The Wax-Wax Ball! | 22.29%
```

It may be worth having additional support specifically for scoop now that I think of it, as that has a dedicated `persist` folder for config - something like `%USERPROFILE%/scoop/persist/discrakt/credentials.ini` - I see credentials.ini is [configured to persist](https://github.com/ScoopInstaller/Extras/blob/master/bucket/discrakt.json), not sure how that works with the current relative directory stuff though