### PR TITLE
feat: add Start at Login toggle to tray menu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod autostart;
 pub mod discord;
 pub mod state;
 pub mod trakt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ impl ApplicationHandler for App {
                         self.should_quit.store(true, Ordering::Relaxed);
                         event_loop.exit();
                     }
-                    TrayCommand::TogglePause => {
+                    TrayCommand::TogglePause | TrayCommand::ToggleAutostart => {
                         // State is already updated in poll_events
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a "Start at Login" checkbox to the system tray menu, allowing users to enable/disable automatic startup on login. Implements platform-specific autostart mechanisms for macOS, Windows, and Linux.

## Platform implementations

- **macOS**: LaunchAgent plist at `~/Library/LaunchAgents/com.afonsojramos.discrakt.plist`
- **Windows**: Registry key at `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
- **Linux**: XDG autostart desktop file at `~/.config/autostart/discrakt.desktop`

## Testing

Toggle the checkbox in the tray menu - the setting persists across app restarts and survives system reboots.