### PR TITLE
feat(linux): native KDE tray support with ksni

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,7 +487,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_repr",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -465,8 +499,8 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "discord-rich-presence",
- "gtk",
  "image",
+ "ksni",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "serde",
@@ -530,6 +564,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +605,33 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -647,6 +735,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -937,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1258,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc9a5e60d55371fd681051b05e9b58e1d818f5085f6364afe872c9347311f91"
+dependencies = [
+ "futures-util",
+ "once_cell",
+ "paste",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1493,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1682,6 +1827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1869,18 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2173,6 +2340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,10 +2401,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
@@ -2292,6 +2484,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -2387,6 +2592,34 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2574,6 +2807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2878,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3019,6 +3274,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3050,11 +3314,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3070,6 +3351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3367,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3094,10 +3387,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3112,6 +3417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3433,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3136,6 +3453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3469,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -3330,6 +3659,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid 1.19.0",
+ "windows-sys 0.61.2",
+ "winnow 0.7.14",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb94821ca8a87ca9c298b5d1cbd80e2a8b67115d99f6e4551ac49e42b6a314"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.14",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,4 +3792,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.14",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.111",
+ "winnow 0.7.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = "1.0"
 chrono = "0.4.42"
 webbrowser = "1.0.6"
 dirs = "6.0.0"
-tray-icon = "0.19"
 image = { version = "0.25", default-features = false, features = ["png"] }
 crossbeam-channel = "0.5"
 winit = "0.30"
@@ -27,8 +26,14 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tiny_http = "0.12"
 
+# Platform-specific tray dependencies:
+# - Linux: ksni for native KDE/freedesktop StatusNotifierItem support
+# - Windows/macOS: tray-icon crate
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+tray-icon = "0.19"
+
 [target.'cfg(target_os = "linux")'.dependencies]
-gtk = "0.18"
+ksni = { version = "0.3", features = ["blocking"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,14 @@ pub mod discord;
 pub mod setup;
 pub mod state;
 pub mod trakt;
-pub mod tray;
 pub mod utils;
+
+// Platform-specific tray implementations:
+// - Linux: ksni (KDE StatusNotifierItem) for native KDE/freedesktop support
+// - Windows/macOS: tray-icon crate
+#[cfg(target_os = "linux")]
+#[path = "tray_linux.rs"]
+pub mod tray;
+
+#[cfg(not(target_os = "linux"))]
+pub mod tray;

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,3 +1,8 @@
+//! System tray implementation using tray-icon (Windows/macOS).
+//!
+//! This module is only compiled on non-Linux platforms.
+//! Linux uses the ksni-based implementation in tray_linux.rs.
+
 use crossbeam_channel::Receiver;
 use std::sync::{Arc, RwLock};
 use tray_icon::{

--- a/src/tray_linux.rs
+++ b/src/tray_linux.rs
@@ -1,0 +1,268 @@
+//! Linux-specific tray implementation using ksni (KDE StatusNotifierItem).
+//!
+//! This module provides native integration with KDE Plasma and other desktop environments
+//! that support the freedesktop StatusNotifierItem specification.
+
+use crossbeam_channel::{Receiver, Sender};
+use ksni::blocking::TrayMethods;
+use ksni::menu::*;
+use std::sync::{Arc, RwLock};
+
+use crate::autostart;
+use crate::state::AppState;
+
+/// Commands that can be triggered from the tray menu.
+pub enum TrayCommand {
+    Quit,
+    TogglePause,
+    ToggleAutostart,
+}
+
+/// Internal state shared between the tray icon and the main application.
+struct TrayState {
+    is_paused: bool,
+    autostart_enabled: bool,
+    status_text: String,
+    command_sender: Sender<TrayCommand>,
+}
+
+/// The ksni tray implementation.
+struct DiscraktTray {
+    state: Arc<RwLock<TrayState>>,
+}
+
+impl ksni::Tray for DiscraktTray {
+    // Make left-click open the menu (same as right-click)
+    const MENU_ON_ACTIVATE: bool = true;
+
+    fn id(&self) -> String {
+        "discrakt".into()
+    }
+
+    fn icon_name(&self) -> String {
+        // Use the installed icon from the system icon theme
+        // Falls back to a generic icon if not found
+        "discrakt".into()
+    }
+
+    fn icon_pixmap(&self) -> Vec<ksni::Icon> {
+        // Embed the icon directly as ARGB32 data
+        let icon_bytes = include_bytes!("assets/icon.png");
+        if let Ok(image) = image::load_from_memory(icon_bytes) {
+            let rgba = image.to_rgba8();
+            let (width, height) = rgba.dimensions();
+
+            // Convert RGBA to ARGB (ksni expects ARGB format)
+            let mut argb_data = Vec::with_capacity((width * height * 4) as usize);
+            for pixel in rgba.pixels() {
+                argb_data.push(pixel[3]); // A
+                argb_data.push(pixel[0]); // R
+                argb_data.push(pixel[1]); // G
+                argb_data.push(pixel[2]); // B
+            }
+
+            vec![ksni::Icon {
+                width: width as i32,
+                height: height as i32,
+                data: argb_data,
+            }]
+        } else {
+            vec![]
+        }
+    }
+
+    fn title(&self) -> String {
+        "Discrakt".into()
+    }
+
+    fn tool_tip(&self) -> ksni::ToolTip {
+        let description = self
+            .state
+            .read()
+            .map(|s| format!("Discrakt: {}", s.status_text))
+            .unwrap_or_else(|_| "Discrakt - Trakt to Discord".into());
+
+        ksni::ToolTip {
+            icon_name: String::new(),
+            icon_pixmap: vec![],
+            title: "Discrakt".into(),
+            description,
+        }
+    }
+
+    fn menu(&self) -> Vec<MenuItem<Self>> {
+        let state = self.state.read().ok();
+        let (is_paused, autostart_enabled, status_text) = state
+            .map(|s| (s.is_paused, s.autostart_enabled, s.status_text.clone()))
+            .unwrap_or((false, false, "Starting...".into()));
+
+        vec![
+            // Status display (disabled item, just for showing info)
+            StandardItem {
+                label: status_text,
+                enabled: false,
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            // Pause/Resume toggle
+            StandardItem {
+                label: if is_paused { "Resume" } else { "Pause" }.into(),
+                enabled: true,
+                activate: Box::new(|tray: &mut Self| {
+                    if let Ok(state) = tray.state.read() {
+                        let _ = state.command_sender.send(TrayCommand::TogglePause);
+                    }
+                }),
+                ..Default::default()
+            }
+            .into(),
+            // Autostart toggle (checkmark item)
+            CheckmarkItem {
+                label: "Start at Login".into(),
+                enabled: true,
+                checked: autostart_enabled,
+                activate: Box::new(|tray: &mut Self| {
+                    if let Ok(state) = tray.state.read() {
+                        let _ = state.command_sender.send(TrayCommand::ToggleAutostart);
+                    }
+                }),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            // Quit item
+            StandardItem {
+                label: "Quit Discrakt".into(),
+                enabled: true,
+                activate: Box::new(|tray: &mut Self| {
+                    if let Ok(state) = tray.state.read() {
+                        let _ = state.command_sender.send(TrayCommand::Quit);
+                    }
+                }),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+}
+
+/// Handle to the tray icon, allowing updates from the main thread.
+pub struct Tray {
+    handle: ksni::blocking::Handle<DiscraktTray>,
+    tray_state: Arc<RwLock<TrayState>>,
+    command_receiver: Receiver<TrayCommand>,
+    last_status: String,
+}
+
+impl Tray {
+    /// Creates a new system tray icon.
+    ///
+    /// This spawns a background task to handle the D-Bus StatusNotifierItem protocol.
+    /// The tray icon will appear in KDE Plasma and other compatible desktop environments.
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let (command_sender, command_receiver) = crossbeam_channel::unbounded();
+
+        let tray_state = Arc::new(RwLock::new(TrayState {
+            is_paused: false,
+            autostart_enabled: autostart::is_enabled(),
+            status_text: "Starting...".into(),
+            command_sender,
+        }));
+
+        let tray = DiscraktTray {
+            state: Arc::clone(&tray_state),
+        };
+
+        // Spawn the tray using the blocking API (ksni handles the event loop internally)
+        let handle = tray.spawn().map_err(|e| {
+            tracing::error!("Failed to spawn ksni tray: {}", e);
+            Box::new(std::io::Error::other(format!("ksni spawn failed: {}", e)))
+                as Box<dyn std::error::Error>
+        })?;
+
+        tracing::info!("System tray initialized (ksni/StatusNotifierItem)");
+
+        Ok(Tray {
+            handle,
+            tray_state,
+            command_receiver,
+            last_status: String::new(),
+        })
+    }
+
+    /// Updates the tray status display based on the current application state.
+    pub fn update_status(&mut self, state: &Arc<RwLock<AppState>>) {
+        if let Ok(app_state) = state.read() {
+            let status = app_state.status_text();
+            let is_paused = app_state.is_paused;
+
+            if status != self.last_status {
+                if let Ok(mut tray_state) = self.tray_state.write() {
+                    tray_state.status_text = status.clone();
+                    tray_state.is_paused = is_paused;
+                }
+
+                // Signal ksni to refresh the tray
+                self.handle.update(|_| {});
+
+                self.last_status = status;
+            }
+        }
+    }
+
+    /// Polls for menu events and returns any command that was triggered.
+    pub fn poll_events(&mut self, state: &Arc<RwLock<AppState>>) -> Option<TrayCommand> {
+        if let Ok(command) = self.command_receiver.try_recv() {
+            match &command {
+                TrayCommand::Quit => {
+                    tracing::info!("Quit requested from tray menu");
+                }
+                TrayCommand::TogglePause => {
+                    if let Ok(mut app_state) = state.write() {
+                        let new_paused = !app_state.is_paused;
+                        app_state.set_paused(new_paused);
+
+                        if let Ok(mut tray_state) = self.tray_state.write() {
+                            tray_state.is_paused = new_paused;
+                        }
+
+                        // Refresh the tray menu
+                        self.handle.update(|_| {});
+
+                        if new_paused {
+                            tracing::info!("Paused from tray menu");
+                        } else {
+                            tracing::info!("Resumed from tray menu");
+                        }
+                    }
+                }
+                TrayCommand::ToggleAutostart => {
+                    match autostart::toggle() {
+                        Ok(enabled) => {
+                            if let Ok(mut tray_state) = self.tray_state.write() {
+                                tray_state.autostart_enabled = enabled;
+                            }
+                            // Refresh the tray menu
+                            self.handle.update(|_| {});
+                            tracing::info!(
+                                "Autostart {}",
+                                if enabled { "enabled" } else { "disabled" }
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to toggle autostart: {}", e);
+                            // Revert checkbox to actual state
+                            if let Ok(mut tray_state) = self.tray_state.write() {
+                                tray_state.autostart_enabled = autostart::is_enabled();
+                            }
+                            self.handle.update(|_| {});
+                        }
+                    }
+                }
+            }
+            return Some(command);
+        }
+        None
+    }
+}


### PR DESCRIPTION
## Summary

Adds native KDE Plasma tray support using the `ksni` crate for proper StatusNotifierItem (SNI) integration.

### Problem

The `tray-icon` crate uses libappindicator on Linux, which has known compatibility issues with KDE Plasma - the tray icon was not visible.

### Solution

- Use `ksni` crate on Linux for native D-Bus StatusNotifierItem protocol
- Keep `tray-icon` for Windows/macOS (unchanged)
- Platform-specific module dispatch via `#[cfg(target_os = "linux")]`

### Changes

- Add `src/tray_linux.rs` - ksni-based tray implementation
- Update `src/lib.rs` - conditional module loading
- Update `src/main.rs` - periodic tray status updates (1s interval)
- Add `ksni` dependency (Linux only)

### Testing

- [x] Tray icon visible on KDE Plasma
- [x] Left-click opens menu
- [x] Status updates correctly
- [x] Quit menu item works