### PR TITLE
feat: add pre-commit hooks for clippy and cargo fmt

### DIFF
--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Install git hooks for Discrakt development
+#
+# Usage: ./.githooks/install.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Installing git hooks..."
+
+# Configure git to use the .githooks directory
+git config core.hooksPath .githooks
+
+echo "Git hooks installed successfully!"
+echo ""
+echo "The following hooks are now active:"
+echo "  - pre-commit: runs cargo fmt --check and clippy"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Pre-commit hook for Rust projects
+# Runs cargo fmt and clippy before allowing commits
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Check if cargo is available
+if ! command -v cargo &> /dev/null; then
+    echo "Error: cargo not found. Please install Rust."
+    exit 1
+fi
+
+# Run cargo fmt --check
+echo "Checking formatting with cargo fmt..."
+if ! cargo fmt -- --check; then
+    echo ""
+    echo "Formatting issues found. Run 'cargo fmt' to fix them."
+    exit 1
+fi
+
+# Run clippy
+echo "Running clippy..."
+if ! cargo clippy -- -D warnings; then
+    echo ""
+    echo "Clippy found issues. Please fix them before committing."
+    exit 1
+fi
+
+echo "All pre-commit checks passed!"


### PR DESCRIPTION
## Summary
Add automated pre-commit hooks to enforce code formatting and linting standards. Contributors can optionally enable hooks using the provided setup script for local development.

## What's included
- `.githooks/pre-commit` - Runs cargo fmt and clippy before commits
- `.githooks/install.sh` - Setup script to enable hooks for development

## Installation
Run `./.githooks/install.sh` to configure git to use these hooks locally.