### PR TITLE
fix: install desktop-file-utils for appimagetool validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y libgtk-3-dev libappindicator3-dev libxdo-dev
+          sudo apt install -y libgtk-3-dev libappindicator3-dev libxdo-dev desktop-file-utils
 
       - name: Install packaging tools
         run: cargo install cargo-deb cargo-generate-rpm


### PR DESCRIPTION
Fixes the [CI failure](https://github.com/afonsojramos/discrakt/actions/runs/20082944835) in the Linux release job where appimagetool required the `desktop-file-validate` command to validate `.desktop` files during AppImage creation.

This adds `desktop-file-utils` to the system dependencies installation step so the validation command is available.