### PR TITLE
feat: add Homebrew publishing support and improve installation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Upload MSI installer
           gh release upload ${{ github.ref_name }} "target/wix/Discrakt_${{ steps.version.outputs.VERSION }}_win64.msi"
+          # Upload standalone exe for Scoop
+          Copy-Item "target/release/discrakt.exe" "target/release/discrakt_win64.exe"
+          gh release upload ${{ github.ref_name }} "target/release/discrakt_win64.exe"
 
   publish-macos:
     runs-on: macos-14
@@ -365,10 +369,66 @@ jobs:
           xcrun stapler staple "$DMG_PATH"
           xcrun stapler validate "$DMG_PATH"
 
+      - name: Create Homebrew tarballs
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          # Create arm64 tarball
+          mkdir -p target/homebrew/arm64
+          cp target/aarch64-apple-darwin/release/discrakt target/homebrew/arm64/
+          tar -czf "target/homebrew/discrakt-${VERSION}-aarch64-apple-darwin.tar.gz" -C target/homebrew/arm64 discrakt
+
+          # Create x86_64 tarball
+          mkdir -p target/homebrew/x86_64
+          cp target/x86_64-apple-darwin/release/discrakt target/homebrew/x86_64/
+          tar -czf "target/homebrew/discrakt-${VERSION}-x86_64-apple-darwin.tar.gz" -C target/homebrew/x86_64 discrakt
+
+          # Generate SHA256 checksums for Homebrew formula
+          echo "SHA256 checksums for Homebrew formula:"
+          shasum -a 256 target/homebrew/discrakt-${VERSION}-aarch64-apple-darwin.tar.gz
+          shasum -a 256 target/homebrew/discrakt-${VERSION}-x86_64-apple-darwin.tar.gz
+
       - name: Upload binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
             "target/release/Discrakt_${{ steps.version.outputs.VERSION }}_universal.dmg" \
+            "target/homebrew/discrakt-${{ steps.version.outputs.VERSION }}-aarch64-apple-darwin.tar.gz" \
+            "target/homebrew/discrakt-${{ steps.version.outputs.VERSION }}-x86_64-apple-darwin.tar.gz" \
             --clobber
+
+  update-homebrew:
+    needs: publish-macos
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger Homebrew formula update
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          if [ -n "$HOMEBREW_TAP_TOKEN" ]; then
+            PAYLOAD=$(jq -n --arg version "$VERSION" '{"event_type":"update-formula","client_payload":{"version":$version}}')
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token $HOMEBREW_TAP_TOKEN" \
+              https://api.github.com/repos/afonsojramos/homebrew-discrakt/dispatches \
+              -d "$PAYLOAD")
+            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+              echo "Triggered Homebrew formula update (HTTP $HTTP_STATUS)"
+            else
+              echo "Failed to trigger Homebrew formula update (HTTP $HTTP_STATUS)"
+              exit 1
+            fi
+          else
+            echo "HOMEBREW_TAP_TOKEN not set - skipping Homebrew update"
+            echo "To enable automatic updates, create a PAT and add it as HOMEBREW_TAP_TOKEN secret"
+          fi

--- a/README.md
+++ b/README.md
@@ -63,32 +63,64 @@ If you prefer to configure manually or use your own Trakt API application:
 
 </details>
 
-## Running executables
+## Installation
 
-Running the executables is as easy as clicking the provided executables in the latest [release](https://github.com/afonsojramos/discrakt/releases). That's it!
+### macOS
 
-Optionally, after you ensure that everything is running correctly, you can also set the executable to run on startup, so that you don't have to run it manually every time you want to start sharing your watch status.
-
-### Linux/MacOS
-
-Create a script that runs the executable silently and set it to run on startup in [Unix](https://raspberrypi.stackexchange.com/questions/15475/run-bash-script-on-startup)/[MacOS](https://www.karltarvas.com/2020/09/11/macos-run-script-on-startup.html).
+#### Homebrew (recommended)
 
 ```bash
-#!/bin/sh
-nohup ./discrakt > /dev/null &
+brew tap afonsojramos/discrakt
+brew install discrakt
 ```
+
+Supports both Apple Silicon and Intel Macs.
+
+#### DMG
+
+Download the universal DMG from the latest [release](https://github.com/afonsojramos/discrakt/releases) and drag the app to your Applications folder.
 
 ### Windows
 
-You can now use the silent Windows executable, and now you only need to follow [this guide](https://support.microsoft.com/en-us/windows/add-an-app-to-run-automatically-at-startup-in-windows-10-150da165-dcd9-7230-517b-cf3c295d89dd) to run it on startup.
-  
-#### Scoop
+#### Scoop (recommended)
 
-You can install Discrakt in [Scoop](https://scoop.sh/) via the [Extras](https://github.com/ScoopInstaller/Extras) bucket:
 ```powershell
-scoop bucket add extras # Ensure bucket is added first
+scoop bucket add extras
 scoop install discrakt
 ```
+
+#### MSI Installer
+
+Download the MSI installer from the latest [release](https://github.com/afonsojramos/discrakt/releases).
+
+### Linux
+
+#### Debian/Ubuntu (.deb)
+
+```bash
+# Download the .deb for your architecture (amd64 or arm64)
+sudo dpkg -i discrakt_*_amd64.deb
+```
+
+#### Fedora/RHEL (.rpm)
+
+```bash
+# Download the .rpm for your architecture (x86_64 or aarch64)
+sudo rpm -i discrakt-*.x86_64.rpm
+```
+
+#### AppImage
+
+Download the AppImage for your architecture from the latest [release](https://github.com/afonsojramos/discrakt/releases), make it executable, and run:
+
+```bash
+chmod +x Discrakt-*-x86_64.AppImage
+./Discrakt-*-x86_64.AppImage
+```
+
+### Running at Startup
+
+Discrakt includes a "Start at Login" option in its system tray menu. Enable it to automatically start when you log in.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Adds Homebrew tap publishing automation and comprehensive installation documentation across all platforms. Includes automated formula updates, improved distribution for Scoop on Windows, and clearer installation instructions.

## Changes

- Create platform-specific tarballs for Homebrew macOS releases
- Auto-trigger Homebrew formula updates after release with SHA256 checksums
- Add standalone Windows exe for Scoop distribution
- Reorganize README with dedicated platform installation sections
- Improve error handling in Homebrew update workflow