### PR TITLE
feat: add CLI support for enabling/disabling autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ chmod +x Discrakt-*-x86_64.AppImage
 
 Discrakt includes a "Start at Login" option in its system tray menu. Enable it to automatically start when you log in.
 
+You can also enable autostart from the command line:
+
+```bash
+discrakt --autostart 1
+```
+
+This is useful for scripting or package manager post-install hooks. To disable:
+
+```bash
+discrakt --autostart 0
+```
+
+### Command Line Options
+
+```
+discrakt [OPTIONS]
+
+Options:
+    --autostart <VALUE>  Enable (1) or disable (0) automatic startup at login
+    --version, -V        Show version information
+    --help, -h           Show help message
+```
+
 ## Development
 
 Make sure you've installed Rust. You can install Rust and its package manager, `cargo` by following the instructions on [rustup.rs](https://rustup.rs/).


### PR DESCRIPTION
## Summary
Added command-line flags to enable/disable automatic startup at login without launching the GUI. Users can now use `discrakt --autostart 1` to enable or `discrakt --autostart 0` to disable start-at-login behavior.

Also added `--version` and `--help` flags for better CLI experience. All flags accept flexible value formats (1/true/on for enable, 0/false/off for disable).

## Test plan
- [x] `discrakt --help` displays usage information
- [x] `discrakt --version` shows version number  
- [x] `discrakt --autostart 1` enables autostart successfully
- [x] `discrakt --autostart 0` disables autostart successfully
- [x] `discrakt --autostart=1` syntax works correctly
- [x] Invalid values display helpful error messages
- [x] All 85 existing tests pass
- [x] Clippy and rustfmt pass with no warnings