### PR TITLE
fix: update AppImage runtime download URL for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           sed -i 's/^          //' target/appimage/Discrakt.AppDir/AppRun
           chmod +x target/appimage/Discrakt.AppDir/AppRun
 
-          wget -q https://github.com/AppImage/AppImageKit/releases/download/13/runtime-aarch64 -O runtime-aarch64
+          wget -q https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-aarch64 -O runtime-aarch64
           ARCH=aarch64 ./appimagetool --runtime-file runtime-aarch64 target/appimage/Discrakt.AppDir target/appimage/Discrakt-${{ steps.version.outputs.VERSION }}-aarch64.AppImage
 
       - name: Upload binaries


### PR DESCRIPTION
Fixes the failing aarch64 AppImage build step by updating the runtime download URL.

The AppImageKit project reorganized their releases, moving runtime files to the separate `type2-runtime` repository. The old URL was returning 404. This updates it to use the correct repository endpoint.