### PR TITLE
fix: display episode/movie title in Discord status

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,5 +1,5 @@
 use discord_rich_presence::{
-    activity::{Activity, ActivityType, Assets, Button, Timestamps},
+    activity::{Activity, ActivityType, Assets, Button, StatusDisplayType, Timestamps},
     DiscordIpc, DiscordIpcClient,
 };
 use std::{thread::sleep, time::Duration};
@@ -210,6 +210,7 @@ impl Discord {
             .details(&payload_data.details)
             .state(&payload_data.state)
             .activity_type(ActivityType::Watching)
+            .status_display_type(StatusDisplayType::Details)
             .assets(
                 Assets::new()
                     .large_image(&img)


### PR DESCRIPTION
## Summary
Display the episode or movie title in Discord's member list status using the `StatusDisplayType::Details` field instead of the generic application name.

This shows specific content information (e.g., "Breaking Bad" or "Inception (2010)") rather than generic labels like "Watching a Show" or "Watching a Movie".

## Changes
- Added `StatusDisplayType` import
- Set `.status_display_type(StatusDisplayType::Details)` on the Activity

Resolves #134