### PR TITLE
ci: add Winget Releaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,7 @@ jobs:
 
     steps:
       - name: Update Winget package
-        uses: vedantmgoyal9/winget-releaser@main
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: afonsojramos.discrakt
           installers-regex: '\.msi$'


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗
Keep it short and sweet 🙌
-->

## 📑 Description

I'm adding Discrakt to Winget (https://github.com/microsoft/winget-pkgs/pull/327072), and this workflow will be used to update it.

**Before merging (you probably already know this):**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @afonsojramos. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

Closes # <!-- Issue # here if applicable -->

## ✅ Checks
- [ ] **code:** My pull request adheres to the code style of this project
- [ ] **docs:** Added / updated
- [ ] **tests:** All the tests have passed

## ℹ Additional Information
