### PR TITLE
ci: pin winget-releaser to latest main commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,7 @@ jobs:
 
     steps:
       - name: Update Winget package
-        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f # main
         with:
           identifier: afonsojramos.discrakt
           installers-regex: '\.msi$'


### PR DESCRIPTION
Updates the winget-releaser action to pin to the latest commit on the main branch instead of the outdated v2 tag. This provides both security (specific commit hash) and keeps dependencies current, addressing feedback from PR #197.