### PR TITLE
ci: allow winget-releaser to fail until package exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,8 @@ jobs:
 
     steps:
       - name: Update Winget package
+        # Allow failure until package exists in winget-pkgs (initial submission pending)
+        continue-on-error: true
         uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f # main
         with:
           identifier: afonsojramos.discrakt


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the winget-releaser step to prevent workflow failures

The `update-winget` job fails because `afonsojramos.discrakt` doesn't exist yet in [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs). The `vedantmgoyal9/winget-releaser` action requires at least one version to already exist before it can auto-update.

This change allows the workflow to continue while the initial package submission is pending. Once the package is accepted in winget-pkgs, the step will start succeeding and we can optionally remove `continue-on-error`.

## Next Steps

Submit initial package manifests to microsoft/winget-pkgs for v3.4.0. The manifests have been prepared and are ready for submission:

**Directory structure for winget-pkgs:**
```
manifests/a/afonsojramos/discrakt/3.4.0/
├── afonsojramos.discrakt.yaml
├── afonsojramos.discrakt.installer.yaml
└── afonsojramos.discrakt.locale.en-US.yaml
```

## Test plan

- [ ] Verify workflow runs without failing (step may show warning but won't block release)
- [ ] After winget-pkgs submission is merged, verify step succeeds