### PR TITLE
chore: add panic hook to capture crashes in log file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,9 +97,17 @@ fn setup_panic_hook() {
         let backtrace = std::backtrace::Backtrace::force_capture();
         let panic_msg = format!(
             "PANIC at {}: {}\n\nBacktrace:\n{}",
-            panic_info.location().map_or("unknown".to_string(), |l| l.to_string()),
-            panic_info.payload().downcast_ref::<&str>().copied()
-                .or_else(|| panic_info.payload().downcast_ref::<String>().map(|s| s.as_str()))
+            panic_info
+                .location()
+                .map_or("unknown".to_string(), |l| l.to_string()),
+            panic_info
+                .payload()
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| panic_info
+                    .payload()
+                    .downcast_ref::<String>()
+                    .map(|s| s.as_str()))
                 .unwrap_or("Unknown panic"),
             backtrace
         );


### PR DESCRIPTION
## Summary
Adds a panic hook that captures Rust panics with full backtraces in the log file. This helps diagnose crashes that were previously invisible.

## Changes
- Added `setup_panic_hook()` function that:
  - Captures panic info and backtrace
  - Logs via tracing (may not flush)
  - Writes directly to log file to ensure capture before process exit
- Called after logging initialization in `main()`

## Why both tracing and direct file write?
The non-blocking tracing channel may not flush before the process dies. Direct file write ensures the panic is captured.