### PR TITLE
fix(trakt): use /users/me when OAuth token is present

### DIFF
--- a/src/trakt.rs
+++ b/src/trakt.rs
@@ -1,9 +1,9 @@
 use lru::LruCache;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::Deserialize;
 use serde_json::Value;
 use std::{collections::HashMap, num::NonZeroUsize, time::Duration};
 use ureq::Agent;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use crate::retry::{execute_with_retry, RetryConfig, RetryError};
 use crate::utils::{user_agent, MediaType};
@@ -300,7 +300,6 @@ impl Trakt {
             }
         }
     }
-
 
     /// Fetches the poster image URL from TMDB for the given media.
     ///


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗
Keep it short and sweet 🙌
-->

## 📑 Description
While using the `/users/<username>/watching` endpoint with OAuth enabled, I noticed repeated `405 Method Not Allowed` errors in the logs.

After switching OAuth-authenticated requests to use `/users/me/watching` instead, the issue was resolved and watching status updates correctly again.

### logs before (results in 405)
```rust
2026-01-25T18:28:09.490601Z  INFO main discrakt::utils: Refresh token is still valid, refreshing access token
2026-01-25T18:28:09.490708Z  INFO main discrakt::utils: Attempting to refresh OAuth access token
2026-01-25T18:28:09.702941Z  INFO main discrakt::utils: Successfully refreshed OAuth access token
2026-01-25T18:28:09.703693Z  INFO main discrakt::utils: Token refreshed successfully expires_at=2026-04-25T18:28:09Z
2026-01-25T18:28:09.816635Z DEBUG main discrakt::tray: Dark mode detected, using light tray icon
2026-01-25T18:28:09.851966Z  INFO main discrakt::tray: System tray initialized
2026-01-25T18:28:09.852018Z  INFO main discrakt: Discrakt is running in the system tray
2026-01-25T18:28:25.056070Z ERROR ThreadId(04) discrakt::trakt: Unexpected HTTP error from Trakt API endpoint=https://api.trakt.tv/users/<username>/watching status=405
2026-01-25T18:28:25.056123Z DEBUG ThreadId(04) discrakt: Nothing is being played
```

### logs after (works correctly)
During and after it being finished
```rust
2026-01-25T16:32:23.582126Z  INFO main discrakt::utils: Refresh token is still valid, refreshing access token
2026-01-25T16:32:23.582232Z  INFO main discrakt::utils: Attempting to refresh OAuth access token
2026-01-25T16:32:23.784792Z  INFO main discrakt::utils: Successfully refreshed OAuth access token
2026-01-25T16:32:23.785625Z  INFO main discrakt::utils: Token refreshed successfully expires_at=2026-04-25T16:32:23Z
2026-01-25T16:32:23.902010Z DEBUG main discrakt::tray: Dark mode detected, using light tray icon
2026-01-25T16:32:23.940390Z  INFO main discrakt::tray: System tray initialized
2026-01-25T16:32:23.940670Z  INFO main discrakt: Discrakt is running in the system tray
2026-01-25T16:32:39.222034Z  INFO ThreadId(04) discrakt::discord: Switching Discord app ID from 144xxxxx to 144xxxxx
2026-01-25T16:32:39.447215Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:32:39.507364Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=96.10%
2026-01-25T16:32:54.670912Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:32:54.671000Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=96.71%
2026-01-25T16:33:09.846318Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:33:09.846439Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=97.32%
2026-01-25T16:33:25.017916Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:33:25.018003Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=97.97%
2026-01-25T16:33:40.190503Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:33:40.190603Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=98.58%
2026-01-25T16:33:55.441213Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:33:55.441441Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=99.19%
2026-01-25T16:34:10.636641Z  WARN ThreadId(04) discrakt::trakt: Image not found in TMDB response media_type=episode
2026-01-25T16:34:10.636742Z  INFO ThreadId(04) discrakt::discord: Now playing details=Body Cam state=S10E05 - White House of Horror progress=99.80%
2026-01-25T16:34:25.778376Z DEBUG ThreadId(04) discrakt::trakt: Failed to parse watching response (may be empty) endpoint=https://api.trakt.tv/users/me/watching error=json: EOF while parsing a value at line 1 column 0
2026-01-25T16:34:25.778452Z DEBUG ThreadId(04) discrakt: Nothing is being played
2026-01-25T16:34:40.912360Z DEBUG ThreadId(04) discrakt::trakt: Failed to parse watching response (may be empty) endpoint=https://api.trakt.tv/users/me/watching error=json: EOF while parsing a value at line 1 column 0
2026-01-25T16:34:40.912410Z DEBUG ThreadId(04) discrakt: Nothing is being played
```



## ✅ Checks
- [x] **code:** My pull request adheres to the code style of this project | seems like it :)
- [ ] **docs:** Added / updated | `N/A`
- [x] **tests:** All the tests have passed

## ℹ Additional Information
I'm not a software engineer, so please double-check the changes.

### `/users/<username>/watching` endpoint
<img width="1335" height="120" alt="username_endpoint" src="https://github.com/user-attachments/assets/b47be1d8-7677-4762-8ec5-b7a061e98d9f" />

### `/users/me/watching` endpoint
<img width="1333" height="241" alt="me_endpoint" src="https://github.com/user-attachments/assets/f90baf00-1a27-4983-a409-12c9c5b1aafc" />

