### PR TITLE
chore(deps): upgrade discord-rich-presence to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "discord-rich-presence"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead3c5edc7e048c317c6fc4a7e24aff0c7e4c136918e2ba38106a385b2cc53a5"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = [".github/*", "docs/*.psd", "credentials.ini", ".gitignore"]
 
 [dependencies]
-discord-rich-presence = "1.0.0"
+discord-rich-presence = "1.1.0"
 ureq = { version = "3", features = ["json"] }
 configparser = { version = "3.1.0", features = ["indexmap"] }
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Summary
Upgrade discord-rich-presence from 1.0.0 to 1.1.0, which includes pipe existence validation, optional name field override, and internal type safety improvements.

## What's new in v1.1.0
- Pipe existence validation: Better IPC socket discovery on macOS when XDG_RUNTIME_DIR is set differently than TMPDIR
- Name field override: New optional activity.name() method for customization
- Generic types and internal improvements for better type safety

## Testing
All existing tests pass, clippy checks pass, and cargo builds successfully. No code changes required in discrakt as the new features are backward compatible.