### PR TITLE
fix: explicitly clear Discord activity before closing connection

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -125,6 +125,10 @@ impl Discord {
         }
     }
 
+    pub fn clear_activity(&mut self) {
+        let _ = self.client.clear_activity();
+    }
+
     pub fn close(&mut self) {
         let _ = self.client.close();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let is_paused = app_state_clone.read().map(|s| s.is_paused).unwrap_or(false);
 
             if is_paused {
+                discord.clear_activity();
                 discord.close();
                 continue;
             }
@@ -422,6 +423,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if let Ok(mut state) = app_state_clone.write() {
                         state.clear_watching();
                     }
+                    discord.clear_activity();
                     discord.close();
                     continue;
                 }
@@ -434,6 +436,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Ok(mut state) = app_state_clone.write() {
                     state.clear_watching();
                 }
+                discord.clear_activity();
                 discord.close();
                 continue;
             }
@@ -467,6 +470,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             discord.set_activity(&response, &mut trakt, tmdb_token.clone());
         }
 
+        discord.clear_activity();
         discord.close();
         tracing::info!("Polling thread stopped");
     });


### PR DESCRIPTION
## Summary
- Add `clear_activity()` method to `Discord` struct that calls the discord-rich-presence crate's `clear_activity()` 
- Call `clear_activity()` before `close()` when paused, when nothing is playing, when activity expires, and on shutdown

## Problem
Issue #212 reports that Discord activity persists indefinitely after Trakt activity expires or when quitting via the tray icon. The root cause is that `discord.close()` only closes the IPC connection - Discord doesn't automatically clear the Rich Presence when an app disconnects.

## Solution
The `discord-rich-presence` crate provides a `clear_activity()` method that explicitly tells Discord to stop showing the activity. This PR calls it before every `close()`.

## Test plan
- [ ] Start watching something on Trakt
- [ ] Verify Discord shows the activity  
- [ ] Stop watching on Trakt
- [ ] Verify Discord activity clears within 15 seconds
- [ ] Quit via tray icon while watching
- [ ] Verify Discord activity clears immediately

Closes #212