### PR TITLE
build(windows): statically link MSVC runtime

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary
- Link the MSVC C runtime statically into Windows builds so `discrakt.exe` no longer depends on `Microsoft.VCRedist.2015+.x64` at runtime.
- Applied via `rustflags = ["-C", "target-feature=+crt-static"]` under `[target.x86_64-pc-windows-msvc]` in `.cargo/config.toml`, so it is picked up automatically by the `cargo build --release` step in `publish-win`.

## Motivation
The winget-pkgs validator rejected [microsoft/winget-pkgs#360530](https://github.com/microsoft/winget-pkgs/pull/360530) with `STATUS_DLL_NOT_FOUND` (exit code `-1073741515`) because the clean validator VM had no VCRedist installed. Rather than declaring VCRedist as a `PackageDependencies` entry for every future manifest, statically linking the CRT removes the dependency at the source. Users without VCRedist (surprisingly common) will also be able to run the installer without a redistributable install step.

## Trade-offs
- Binary grows by a few hundred KB.
- Safe for this project: the dep tree (`ureq`, `discord-rich-presence`, `tray-icon`, etc.) is pure Rust or FFI that does not share CRT allocations with external DLLs.

## Test plan

### Verified in CI (this PR)
- [x] `build-artifacts` Windows job produces a working `discrakt.exe` with the static-CRT rustflag applied.
- [x] Import table of the built `discrakt.exe` contains no dynamic CRT dependencies. Verified via `objdump -p discrakt.exe | grep "DLL Name"`:
  - **Present (all OS-provided):** `kernel32.dll`, `ntdll.dll`, `user32.dll`, `advapi32.dll`, `gdi32.dll`, `shell32.dll`, `shlwapi.dll`, `comctl32.dll`, `combase.dll`, `ws2_32.dll`, `bcrypt.dll`, `bcryptprimitives.dll`, `api-ms-win-core-synch-l1-2-0.dll` (Windows API Set, not CRT).
  - **Absent (the goal):** no `VCRUNTIME140.dll`, no `MSVCP140.dll`, no `api-ms-win-crt-*.dll`.

### Post-release (v3.4.4)
- [ ] Confirm the `publish-win` job produces a working `.exe` and MSI on the next tagged release.
- [ ] Confirm the winget-pkgs validator (a clean VM without VCRedist — same tooling that rejected [#360530](https://github.com/microsoft/winget-pkgs/pull/360530)) accepts the auto-submitted 3.4.4 manifest.
- [ ] Strip the inherited `PackageDependencies: Microsoft.VCRedist.2015+.x64` from the auto-submitted 3.4.4 manifest so future versions no longer carry it forward.