### PR TITLE
ci: replace archived actions-rs/clippy-check with direct cargo clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,23 +23,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Check workflow permissions
-        id: check_permissions
-        uses: scherermichael-oss/action-has-permission@1.0.6
-        with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run clippy
-        if: ${{ steps.check_permissions.outputs.has-permission }}
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D clippy::all
-
-      - name: Run clippy without annotations
-        if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: cargo clippy --all-features --all-targets -- -D warnings
 
   rustfmt:


### PR DESCRIPTION
## Summary
Replace the archived [`actions-rs/clippy-check@v1`](https://github.com/actions-rs/clippy-check) with a direct `cargo clippy` invocation, and drop the no-longer-needed [`scherermichael-oss/action-has-permission@1.0.6`](https://github.com/scherermichael-oss/action-has-permission) permission gate.

## Motivation
- The `actions-rs` organization was archived in 2022. `actions-rs/clippy-check` itself is archived (verified via GitHub API).
- `scherermichael-oss/action-has-permission` last released in 2019 and only existed to gate the write-token-requiring `clippy-check` action — once it is gone, the permission check has no purpose.
- Running `cargo clippy` directly is the idiomatic modern approach used by `tokio`, `syn`, and most of the Rust ecosystem.

## Strictness preserved
| Path | Previous flag | New flag |
| --- | --- | --- |
| Privileged (had write token) | `-- -D clippy::all` | `-- -D warnings` |
| Unprivileged (fork PRs, etc.) | `-- -D warnings` | `-- -D warnings` |

`-D warnings` is strictly ≥ `-D clippy::all` (it also covers rustc warnings). No regression in lint strictness for anyone; fork PR contributors now get the same lints as the maintainer.

## Trade-offs
- Inline PR annotations from the old `clippy-check` action are gone. Clippy output still appears in the Actions log. If PR annotations become worth re-adding, a non-archived alternative (e.g. `clechasseur/rs-clippy-check`) can be adopted in a follow-up.

## Test plan
- [ ] CI runs `Clippy` and `Format` jobs successfully on this PR.
- [ ] Step count drops from 5 steps to 4 in the Clippy job (checkout, toolchain, apt cache, rust cache, clippy — the permission check is gone).