### PR TITLE
ci: pin cache-apt-pkgs-action to v1.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libgtk-3-dev libappindicator3-dev libxdo-dev
           version: 1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libgtk-3-dev libappindicator3-dev libxdo-dev
           version: 1.0


### PR DESCRIPTION
## Summary
Pin `awalsh128/cache-apt-pkgs-action` from the floating `@latest` tag to the explicit `@v1.6.0` release in both `build.yml` and `lint.yml`.

## Motivation
`@latest` is a moving target that Dependabot cannot track. Pinning to a specific release makes version changes explicit, auditable, and bumpable by the existing Dependabot `github-actions` config.

## Why v1.6.0 specifically — not @v1
This is not purely stylistic; the maintainer's floating tags are actually behind the latest release. As of today:

| Tag | Resolves to commit | Date |
| --- | --- | --- |
| `@latest` | `2c09a5e` | 2025-08-11 (~v1.5.3 era) |
| `@v1` | `2c09a5e` | 2025-08-11 (~v1.5.3 era) |
| `@v1.6.0` | `acb598e` | 2025-10-04 |

Pinning to `@v1.6.0` therefore both removes the `@latest` antipattern and picks up the Oct 2025 fixes (invalid-line skipping, ls-error fix on empty caches, PPA support).

## Test plan
- [x] `Build` and `Clippy` jobs pass on this PR (they install the same APT packages, so a broken action would fail the step).