### PR TITLE
ci: drop dead Rust version matrix in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   build:
     name: Build
-    strategy:
-      matrix:
-        rust-version: ["1.70", "stable"]
     runs-on: ubuntu-latest
     steps:
       - name: Repository Checkout


### PR DESCRIPTION
## Summary
Remove the `strategy.matrix.rust-version: ["1.70", "stable"]` declaration from the `Build` job, since its value is never read by the `Install Rust` step and has no effect.

## What the matrix was supposed to do
Test the crate against both a pinned older Rust (1.70) and `stable`.

## What it was actually doing
Nothing. The step that installs the toolchain hardcodes `dtolnay/rust-toolchain@stable` — the ref on that action is a git branch named `stable`, not a matrix variable. As a result:
- Both matrix entries installed the same `stable` toolchain.
- CI ran the same test suite twice under two different display names (`Build (1.70)`, `Build (stable)`), wasting runner minutes.
- No MSRV regression was ever actually caught by this setup.

## Why not fix it by wiring through the matrix
- Effective MSRV is 1.85 (constrained by `ureq 3.x` and `winit 0.30`). `1.70` would not build even if wired up.
- A proper MSRV check belongs at the `Cargo.toml` `rust-version` layer, which cargo itself enforces at build time — no matrix required. That will be proposed in a follow-up PR.
- `discrakt` is a distributed binary crate, not a library; users are not expected to build it against arbitrary old toolchains.

## Test plan
- [ ] One `Build` check appears on this PR instead of two.
- [ ] The single `Build` run still succeeds.