### PR TITLE
build: declare Cargo.toml rust-version MSRV 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "discrakt"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.88"
 authors = ["afonsojramos"]
 description = "Easy to Use Trakt/Plex Discord Rich Presence"
 repository = "https://github.com/afonsojramos/discrakt"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/afonsojramos/discrakt/actions/workflows/main.yml"><img src="https://github.com/afonsojramos/discrakt/actions/workflows/build.yml/badge.svg"></a>
   <a href="https://deps.rs/repo/github/afonsojramos/discrakt"><img src="https://deps.rs/repo/github/afonsojramos/discrakt/status.svg"></a>
-  <a href="https://github.com/afonsojramos/discrakt/"><img src="https://img.shields.io/badge/rustc-1.58-blue.svg"></a>
+  <a href="https://github.com/afonsojramos/discrakt/"><img src="https://img.shields.io/badge/rustc-1.88-blue.svg"></a>
   <a href="https://github.com/afonsojramos/discrakt/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 </p>
 
@@ -20,6 +20,7 @@ A simple app that acts as a bridge between [Discord](https://discord.com/) and [
 **How it works**: Discrakt polls your Trakt.tv account for "currently watching" status and displays it on Discord. For this to work, **your streaming app must scrobble to Trakt** — meaning it reports what you're watching to Trakt in real-time.
 
 Popular apps with Trakt integration include:
+
 - **Stremio** — Enable the [Trakt addon](https://www.stremio.com/addons) in Settings → Addons
 - **Plex** — Use the [Plex-Trakt-Scrobbler](https://github.com/trakt/Plex-Trakt-Scrobbler) plugin
 - **Kodi**, **Infuse**, **VLC** and [many more](https://trakt.tv/apps)
@@ -29,7 +30,7 @@ Once your app is scrobbling to Trakt, Discrakt will display your watch status on
 ## Features
 
 - 🌐 **Multilingual support** (Automatic system detection & Tray menu selection)
-  - *Localized titles for movies and episodes are fetched via TMDB.*
+  - _Localized titles for movies and episodes are fetched via TMDB._
 - Separate Discord Rich Presence apps for Movies and TV Shows
 - Movie posters and show artwork displayed via TMDB
 - Direct links to IMDB and Trakt pages
@@ -51,7 +52,7 @@ Plex Rich Presence alternatives:
 
 A default Trakt Client ID is provided, so you don't need to create your own API application.
 
-*Note: Discord needs to be running on the same machine as Discrakt.*
+_Note: Discord needs to be running on the same machine as Discrakt._
 
 <details>
 <summary><strong>Advanced: Manual Configuration</strong></summary>
@@ -62,11 +63,11 @@ If you prefer to configure manually or use your own Trakt API application:
 2. Create a `credentials.ini` file with your settings
 3. Place it in one of these locations:
 
-|Operating System|Location|Example|
-|--------|-----|-------|
-|Linux|`$XDG_CONFIG_HOME`/discrakt or `$HOME`/.config/discrakt|/home/alice/.config/discrakt/credentials.ini|
-|macOS|`$HOME`/Library/Application Support/discrakt|/Users/Alice/Library/Application Support/discrakt/credentials.ini|
-|Windows|`%APPDATA%`\discrakt|C:\Users\Alice\AppData\Roaming\discrakt\credentials.ini|
+| Operating System | Location                                                | Example                                                           |
+| ---------------- | ------------------------------------------------------- | ----------------------------------------------------------------- |
+| Linux            | `$XDG_CONFIG_HOME`/discrakt or `$HOME`/.config/discrakt | /home/alice/.config/discrakt/credentials.ini                      |
+| macOS            | `$HOME`/Library/Application Support/discrakt            | /Users/Alice/Library/Application Support/discrakt/credentials.ini |
+| Windows          | `%APPDATA%`\discrakt                                    | C:\Users\Alice\AppData\Roaming\discrakt\credentials.ini           |
 
 </details>
 
@@ -96,6 +97,7 @@ winget install afonsojramos.discrakt
 ```
 
 #### Scoop
+
 ```powershell
 scoop bucket add extras
 scoop install discrakt


### PR DESCRIPTION
## Summary
Declare the project's real Minimum Supported Rust Version in `Cargo.toml` and align the badge in `README.md`.

## Motivation
- `Cargo.toml` had no `rust-version` field at all, so cargo was not enforcing anything.
- The real effective MSRV of the current dependency tree is **1.88**, constrained by `image 0.25.x`. Other notable floors: `ureq 3.x` and `winit 0.30` at 1.85, `ksni 0.3` at 1.80, `lru 0.16` at 1.85.

Declaring `rust-version` makes cargo refuse to build with older toolchains at build time, so no separate CI check is needed.

## How the MSRV was determined
Walked the top-level dependency list and inspected each crate's `rust-version`:

| Crate | `rust-version` |
| --- | --- |
| `image 0.25.9` | **1.88.0** ← current floor |
| `ureq 3.x` | 1.85 |
| `winit 0.30` | 1.85 |
| `lru 0.16` | 1.85 |
| `ksni 0.3` | 1.80 |
| `dark-light 2.0` | 1.78 |
| `crossbeam-channel 0.5` | 1.74 |
| `tray-icon 0.21` | 1.73 |
| `thiserror 2` | 1.71 |
| `chrono 0.4` | 1.62 |
| `winreg 0.55` | 1.60 |
| `tiny_http 0.12` | 1.57 |
| `sys-locale 0.3` | 1.56 |

Verified locally with `cargo check --all-targets` on Rust 1.89.0.

## Note on README.md diff
The README diff in this commit contains ~15 lines of incidental markdown reformatting (italic syntax, table spacing, blank lines around lists) applied by an editor-side formatter at edit time. The substantive change is the single `rustc-1.58` → `rustc-1.88` badge bump on line 8. Reviewers are welcome to reject the formatting noise if undesired.

## Test plan
- [ ] `cargo check --all-targets` passes on this PR with Rust 1.88 or newer.
- [ ] Build job passes.