### PR TITLE
ci: standardize Rust dep cache on Swatinem/rust-cache in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           targets: "aarch64-unknown-linux-gnu, x86_64-unknown-linux-musl"
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install system dependencies
         run: |
           sudo apt update
@@ -135,6 +138,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install WiX Toolset v6
         run: dotnet tool install --global wix --version 6.0.2
 
@@ -189,16 +195,8 @@ jobs:
         with:
           targets: "aarch64-apple-darwin, x86_64-apple-darwin"
 
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Extract version
         id: version


### PR DESCRIPTION
## Summary
Add [`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache) to all three release jobs (`publish-linux`, `publish-win`, `publish-macos`), replacing the hand-rolled `actions/cache@v5` block currently used only in `publish-macos`.

## Motivation
- `publish-linux` and `publish-win` currently build all Rust dependencies from scratch on every tagged release. For `publish-linux` this is particularly painful — it compiles both the amd64 native target and the aarch64 cross-compilation target.
- `publish-macos` does cache, but with a hand-rolled `actions/cache@v5` step that keys only on `Cargo.lock` and caches `~/.cargo/bin/` — an anti-pattern that lets stale locally-installed binaries accumulate across cache hits.
- `rust-cache@v2` is the ecosystem-standard action: it auto-detects cross-compilation targets installed via `dtolnay/rust-toolchain with: targets:`, prunes unused deps from the cache to reduce size, and keys on both `Cargo.lock` and the installed toolchain version.
- Already used in `build.yml` and `lint.yml`, so this standardizes on one caching mechanism repo-wide.

## Changes
- `publish-linux`: add `Rust cache` step after `Install Rust`, before `Install system dependencies`.
- `publish-win`: add `Rust cache` step after `Install Rust`, before `Install WiX Toolset v6`.
- `publish-macos`: replace the hand-rolled `actions/cache@v5` step with `Swatinem/rust-cache@v2`.

## Compatibility notes
- `rust-cache@v2` automatically picks up the cross-compilation targets declared in `dtolnay/rust-toolchain` with-clause, so aarch64-linux-gnu, aarch64-apple-darwin, and x86_64-apple-darwin cross-compile artifacts will all cache correctly.
- First release after merge: cache miss on all three runners (as expected on any cache key change). Subsequent releases: substantial speedup.
- `cargo install cargo-deb cargo-generate-rpm` in `publish-linux` will get some incidental cache benefit from `rust-cache`'s `cache-bin: true` default, but this is superseded by #246 (pending) which replaces `cargo install` with `taiki-e/install-action` for prebuilt binaries.

## Test plan
- [ ] Workflow still valid (GitHub Actions lints the YAML on push).
- [ ] On the next `release: published` event, all three jobs complete successfully.
- [ ] Second subsequent release is observably faster than the first.