### PR TITLE
ci: install cargo-deb via prebuilt binary using taiki-e/install-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,13 @@ jobs:
           sudo apt update
           sudo apt install -y libgtk-3-dev libappindicator3-dev libxdo-dev desktop-file-utils
 
-      - name: Install packaging tools
-        run: cargo install cargo-deb cargo-generate-rpm
+      - name: Install cargo-deb (prebuilt)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deb
+
+      - name: Install cargo-generate-rpm
+        run: cargo install cargo-generate-rpm
 
       - name: Build amd64
         run: cargo build --release


### PR DESCRIPTION
## Summary
Swap `cargo install cargo-deb` for [`taiki-e/install-action@v2`](https://github.com/taiki-e/install-action) in `publish-linux`, which downloads cargo-deb's prebuilt Debian-packaged binary from its GitHub releases instead of compiling from source. `cargo-generate-rpm` continues to be installed via `cargo install`.

## Motivation
`cargo install cargo-deb cargo-generate-rpm` compiles both tools from source on every tagged release, adding multiple minutes to `publish-linux`. `taiki-e/install-action` downloads prebuilt binaries in seconds.

## Why only cargo-deb, not both
I checked the `taiki-e/install-action` manifest directory. `cargo-deb` is supported (current prebuilt: v3.6.3, published by `kornelski/cargo-deb` on GitHub releases). `cargo-generate-rpm` is **not** in the manifest list, and the upstream project (`cat-in-136/cargo-generate-rpm`) publishes GitHub releases without asset binaries, so neither `taiki-e/install-action` nor `cargo-binstall` can accelerate it — `cargo install` remains the only option. Splitting the step makes the asymmetry explicit in the workflow.

## Expected speedup
- Removed: source-compile of cargo-deb (multiple minutes).
- Retained: source-compile of cargo-generate-rpm (smaller tool, but still non-trivial).
- Net: roughly halves the "Install packaging tools" cost on the release runner.

## Test plan
- [ ] Next `release: published` event completes `publish-linux` with the new step.
- [ ] `cargo deb --no-build --deb-version=…` succeeds using the downloaded `cargo-deb` binary.
- [ ] `cargo generate-rpm` still succeeds from `cargo install`.