### PR TITLE
docs: clarify credentials.ini is auto-created and not in releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _Note: Discord needs to be running on the same machine as Discrakt._
 <details>
 <summary><strong>Advanced: Manual Configuration</strong></summary>
 
-If you prefer to configure manually or use your own Trakt API application:
+Discrakt creates `credentials.ini` for you during the setup wizard, so this file is **not** included in releases — you don't need to download it. Only follow these steps if you want to use your own Trakt API application:
 
 1. Create an API Application on [Trakt.tv](https://trakt.tv/oauth/applications/new) (with scrobble capabilities and `urn:ietf:wg:oauth:2.0:oob` as the redirect uri)
 2. Create a `credentials.ini` file with your settings


### PR DESCRIPTION
## Summary

Clarifies the "Advanced: Manual Configuration" section in the README to note that `credentials.ini` is created automatically by the setup wizard and is intentionally not included in releases. The manual steps now read as an opt-in path for users who want their own Trakt API application, rather than a file to download.

Closes #253