### PR TITLE
fix: unblock the v4.0.0 release (Windows build + clippy 1.96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           targets: "aarch64-unknown-linux-gnu, x86_64-unknown-linux-musl"
 
+      # rust-toolchain.toml pins a version-named toolchain, so the cross targets
+      # must be added to it (the action adds them to `stable`, which cargo ignores).
+      - name: Add cross-compile targets to the pinned toolchain
+        run: rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-musl
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -230,6 +235,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: "aarch64-apple-darwin, x86_64-apple-darwin"
+
+      # rust-toolchain.toml pins a version-named toolchain, so the cross targets
+      # must be added to it (the action adds them to `stable`, which cargo ignores).
+      - name: Add cross-compile targets to the pinned toolchain
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # Build the setup-ui in a dedicated step (below) so the cargo build doesn't
+      # depend on pnpm being resolvable on PATH from build.rs.
+      DISCRAKT_SKIP_UI_BUILD: "1"
 
     steps:
       - name: Checkout
@@ -40,6 +44,13 @@ jobs:
 
       - name: Set up Node and pnpm
         uses: jdx/mise-action@v2
+
+      - name: Build setup-ui
+        shell: bash
+        working-directory: setup-ui
+        run: |
+          mise exec -- pnpm install --frozen-lockfile
+          mise exec -- pnpm run build
 
       - name: Build amd64
         run: cargo build --release
@@ -138,6 +149,10 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+    env:
+      # Build the setup-ui in a dedicated step (below); on Windows the mise shims
+      # aren't on PATH for build.rs, so let cargo reuse the prebuilt dist instead.
+      DISCRAKT_SKIP_UI_BUILD: "1"
 
     steps:
       - name: Checkout
@@ -160,6 +175,13 @@ jobs:
 
       - name: Set up Node and pnpm
         uses: jdx/mise-action@v2
+
+      - name: Build setup-ui
+        shell: bash
+        working-directory: setup-ui
+        run: |
+          mise exec -- pnpm install --frozen-lockfile
+          mise exec -- pnpm run build
 
       - name: Build win64
         env:
@@ -196,6 +218,9 @@ jobs:
       contents: write
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
+      # Build the setup-ui in a dedicated step (below) so the per-target cargo
+      # builds reuse one prebuilt dist instead of invoking pnpm from build.rs.
+      DISCRAKT_SKIP_UI_BUILD: "1"
 
     steps:
       - name: Checkout
@@ -218,6 +243,13 @@ jobs:
 
       - name: Set up Node and pnpm
         uses: jdx/mise-action@v2
+
+      - name: Build setup-ui
+        shell: bash
+        working-directory: setup-ui
+        run: |
+          mise exec -- pnpm install --frozen-lockfile
+          mise exec -- pnpm run build
 
       - name: Build arm64 (Apple Silicon)
         run: cargo build --release --target=aarch64-apple-darwin
@@ -438,6 +470,8 @@ jobs:
 
   update-winget:
     needs: publish-win
+    # Skip package-manager updates for pre-releases (e.g. v4.0.0-beta.1).
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
 
     steps:
@@ -450,6 +484,8 @@ jobs:
 
   update-homebrew:
     needs: publish-macos
+    # Skip package-manager updates for pre-releases (e.g. v4.0.0-beta.1).
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
 
     steps:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# Pin the toolchain so local and CI use the exact same rustc/clippy/rustfmt.
+# Bump this deliberately (and run `cargo clippy` locally) when adopting a new
+# Rust release, rather than letting CI's `stable` drift ahead of contributors.
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]

--- a/src/plex_auth.rs
+++ b/src/plex_auth.rs
@@ -228,7 +228,7 @@ pub fn discover_plex_server(
     if candidates.is_empty() {
         return Err("No Plex servers found for this account".to_string());
     }
-    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates.sort_by_key(|b| std::cmp::Reverse(b.0));
 
     // Probe each in preference order; use the first that responds.
     let probe = Agent::config_builder()


### PR DESCRIPTION
The v4.0.0 release run failed on `publish-win` and the Lint CI was red. This branch fixes both so v4.0.0 can be cut cleanly.

## What's fixed
- **Windows release build** (`publish-win` → `Build win64`): `build.rs` invokes `pnpm`, but on Windows the mise shims aren't on PATH, so the frontend build failed (`failed to run pnpm: program not found`). Now each publish job builds `setup-ui` in a dedicated step via `mise exec -- pnpm` (shim-independent) and sets `DISCRAKT_SKIP_UI_BUILD=1` so the cargo build reuses the prebuilt `dist/`. Applied to linux/win/macos for consistency.
- **Clippy 1.96**: CI's `stable` rolled to 1.96.0, whose `unnecessary_sort_by` lint flagged pre-existing `plex_auth.rs`. Fixed via `sort_by_key`.
- **Toolchain drift**: added `rust-toolchain.toml` pinning 1.96.0 so local and CI clippy stay in sync.
- **Pre-release safety**: `update-winget` / `update-homebrew` now skip pre-releases, so beta tags can dress-rehearse the build without touching package managers.

Validated locally: `mise exec -- pnpm run build` produces `dist/`, `DISCRAKT_SKIP_UI_BUILD=1 cargo build` reuses it, clippy/fmt/tests clean on 1.96.0, actionlint clean.