### PR TITLE
ci(release): drop redundant target inputs and guard the setup-ui build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "aarch64-unknown-linux-gnu, x86_64-unknown-linux-musl"
 
-      # rust-toolchain.toml pins a version-named toolchain, so the cross targets
-      # must be added to it (the action adds them to `stable`, which cargo ignores).
+      # Cross targets must go on the rust-toolchain.toml-pinned toolchain that
+      # cargo actually uses (not the `stable` the action installs as default).
       - name: Add cross-compile targets to the pinned toolchain
         run: rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-musl
 
@@ -56,6 +54,7 @@ jobs:
         run: |
           mise exec -- pnpm install --frozen-lockfile
           mise exec -- pnpm run build
+          test -f dist/index.html # fail loudly if the build produced no dist
 
       - name: Build amd64
         run: cargo build --release
@@ -187,6 +186,7 @@ jobs:
         run: |
           mise exec -- pnpm install --frozen-lockfile
           mise exec -- pnpm run build
+          test -f dist/index.html # fail loudly if the build produced no dist
 
       - name: Build win64
         env:
@@ -233,11 +233,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "aarch64-apple-darwin, x86_64-apple-darwin"
 
-      # rust-toolchain.toml pins a version-named toolchain, so the cross targets
-      # must be added to it (the action adds them to `stable`, which cargo ignores).
+      # Cross targets must go on the rust-toolchain.toml-pinned toolchain that
+      # cargo actually uses (not the `stable` the action installs as default).
       - name: Add cross-compile targets to the pinned toolchain
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
@@ -260,6 +258,7 @@ jobs:
         run: |
           mise exec -- pnpm install --frozen-lockfile
           mise exec -- pnpm run build
+          test -f dist/index.html # fail loudly if the build produced no dist
 
       - name: Build arm64 (Apple Silicon)
         run: cargo build --release --target=aarch64-apple-darwin


### PR DESCRIPTION
Post-merge cleanups from the review of the v4.0.0 release fixes. Both are zero-risk to the build (v4.0.0 already shipped green with the underlying behavior).

- **Remove dead `targets:` inputs** on the linux/macos `Install Rust` steps. With `rust-toolchain.toml` pinning the toolchain, those inputs added targets to the unused `stable` toolchain; the explicit `rustup target add` steps (added in the v4.0.0 fix) are what actually put the cross targets on the pinned toolchain. The `targets:` lines were dead and misleading — removed so there's one source of truth.
- **Guard the setup-ui build** with `test -f dist/index.html`. Since `dist/` is embedded at compile time via `include_dir!`, a build that produced no output would otherwise fail deep inside a macro instead of loudly at the build step. Cheap insurance.

actionlint clean. No behavior change to the green release path.