### PR TITLE
feat: support multiple active sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Either way, movie and show artwork plus localized titles are fetched from TMDB.
 ## Features
 
 - Choose your source: **Trakt** (any app that scrobbles to it), or a direct **Plex** or **Jellyfin** server connection
+  - _Several sources can be active at once for dual setups, whichever one is playing gets shown._
 - 🌐 **Multilingual support** (Automatic system detection & Tray menu selection)
   - _Localized titles for movies and episodes are fetched via TMDB._
 - Separate Discord Rich Presence apps for Movies and TV Shows
@@ -50,6 +51,7 @@ Either way, movie and show artwork plus localized titles are fetched from TMDB.
    - **Trakt**: click **Login with Trakt** and approve in your browser. (Advanced: use a public Trakt profile by username, no login.)
    - **Plex**: click **Login with Plex** and approve. (Advanced: enter a server URL + token manually.)
    - **Jellyfin**: enter your server URL and click **Login with Jellyfin**, then enter the shown code in Jellyfin's **Quick Connect**. (Advanced: use an API key.)
+4. Running a dual setup? Click **Add another source** on the success screen and connect the second one. Discrakt then shows whichever source is playing, preferring the one you connected first.
 
 _Note: Discord needs to be running on the same machine as Discrakt._
 
@@ -95,6 +97,25 @@ username = your-jellyfin-username
 ```
 
 `accessToken` can be an API key (Dashboard → API Keys) or a token from Quick Connect. When `source` is omitted, Discrakt prefers Trakt, then Plex, then Jellyfin, based on what's configured.
+
+**Using several sources at once**: the setup wizard writes this for you via **Add another source**, but `source` also accepts a comma-separated list directly, so a dual setup can show your activity whichever server you stream from:
+
+```ini
+[Discrakt]
+source = plex, jellyfin
+
+[Plex]
+serverUrl = http://192.168.1.10:32400
+token = your-x-plex-token
+
+[Jellyfin]
+serverUrl = http://192.168.1.10:8096
+accessToken = your-jellyfin-api-key
+```
+
+Sources are polled in the order listed and the first one playing something wins, so if both are streaming at the same time, Plex is shown in the example above. Polling stops at the first hit, meaning later sources are only contacted when the earlier ones are idle.
+
+Only list sources you have actually configured: an unreachable or unconfigured server still gets polled (and retried) on every cycle, which delays the sources behind it. Listing `trakt` alongside `plex` or `jellyfin` is usually not what you want either, since those servers typically scrobble to Trakt already.
 
 </details>
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 # existing pnpm-lock.yaml, so nothing migrates. build.rs invokes it for setup-ui.
 [tools]
 node = "22"
-"npm:@nubjs/nub" = "0.4.11"
+"npm:@nubjs/nub" = "latest"

--- a/setup-ui/src/App.tsx
+++ b/setup-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, type SyntheticEvent, useEffect, useRef, useState } from "react";
-import { ChevronDown, ExternalLink, Loader2 } from "lucide-react";
+import { Check, ChevronDown, ExternalLink, Loader2 } from "lucide-react";
 
 import { JellyfinIcon, PlexIcon, TraktIcon } from "@/components/brand-icons";
 import { Button } from "@/components/ui/button";
@@ -9,6 +9,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  continueSetup,
+  finishSetup,
   getStatus,
   startJellyfinLogin,
   startPlexLogin,
@@ -18,7 +20,12 @@ import {
   submitTraktPublic,
 } from "@/lib/api";
 
+/** A source the wizard can connect, as shown to the user. */
+type SourceName = "Trakt" | "Plex" | "Jellyfin";
+
 type AuthInfo = {
+  /** The source this authorization belongs to. */
+  source: SourceName;
   /** The URL the user opens to authorize. */
   link: string;
   /** A short code to display (Trakt device code, Jellyfin Quick Connect). */
@@ -37,6 +44,12 @@ type Screen = { name: "setup" } | { name: "auth"; info: AuthInfo } | { name: "su
 export function App() {
   const [screen, setScreen] = useState<Screen>({ name: "setup" });
   const [error, setError] = useState<string | null>(null);
+  const [connected, setConnected] = useState<SourceName[]>([]);
+
+  const markConnected = (source: SourceName) => {
+    setConnected((current) => (current.includes(source) ? current : [...current, source]));
+    setScreen({ name: "success" });
+  };
 
   // While waiting for authorization, poll the server for completion.
   useEffect(() => {
@@ -46,7 +59,7 @@ export function App() {
       try {
         const status = await getStatus();
         if (cancelled) return;
-        if (status.status === "success") setScreen({ name: "success" });
+        if (status.status === "success") markConnected(screen.info.source);
         else if (status.status === "denied")
           setError("Authorization was denied. Restart Discrakt to try again.");
         else if (status.status === "expired")
@@ -85,15 +98,24 @@ export function App() {
             <SetupScreen
               error={error}
               setError={setError}
+              connected={connected}
               onAuth={(info) => {
                 setError(null);
                 setScreen({ name: "auth", info });
               }}
-              onDone={() => setScreen({ name: "success" })}
+              onDone={markConnected}
             />
           )}
           {screen.name === "auth" && <AuthScreen info={screen.info} error={error} />}
-          {screen.name === "success" && <SuccessScreen />}
+          {screen.name === "success" && (
+            <SuccessScreen
+              connected={connected}
+              onAddAnother={() => {
+                setError(null);
+                setScreen({ name: "setup" });
+              }}
+            />
+          )}
         </CardContent>
       </Card>
     </div>
@@ -112,23 +134,35 @@ type SetupProps = {
   error: string | null;
   setError: (message: string | null) => void;
   onAuth: (info: AuthInfo) => void;
-  onDone: () => void;
+  onDone: (source: SourceName) => void;
 };
 
-function SetupScreen({ error, setError, onAuth, onDone }: SetupProps) {
+type SetupScreenProps = SetupProps & { connected: SourceName[] };
+
+function SetupScreen({ error, setError, connected, onAuth, onDone }: SetupScreenProps) {
+  // Land on the first source that is not connected yet, so returning here to
+  // add a second source does not reopen the one just finished.
+  const firstUnconnected =
+    (["trakt", "plex", "jellyfin"] as const).find((tab) => !connected.includes(labelOf(tab))) ??
+    "trakt";
+
   return (
-    <Tabs defaultValue="trakt" onValueChange={() => setError(null)} className="gap-5">
+    <Tabs defaultValue={firstUnconnected} onValueChange={() => setError(null)} className="gap-5">
       <TabsList className="w-full">
         <TabsTrigger value="trakt">
-          <TraktIcon />
+          {connected.includes("Trakt") ? <Check className="text-emerald-500" /> : <TraktIcon />}
           Trakt
         </TabsTrigger>
         <TabsTrigger value="plex">
-          <PlexIcon />
+          {connected.includes("Plex") ? <Check className="text-emerald-500" /> : <PlexIcon />}
           Plex
         </TabsTrigger>
         <TabsTrigger value="jellyfin">
-          <JellyfinIcon />
+          {connected.includes("Jellyfin") ? (
+            <Check className="text-emerald-500" />
+          ) : (
+            <JellyfinIcon />
+          )}
           Jellyfin
         </TabsTrigger>
       </TabsList>
@@ -146,6 +180,11 @@ function SetupScreen({ error, setError, onAuth, onDone }: SetupProps) {
       </TabsContent>
     </Tabs>
   );
+}
+
+function labelOf(tab: "trakt" | "plex" | "jellyfin"): SourceName {
+  if (tab === "trakt") return "Trakt";
+  return tab === "plex" ? "Plex" : "Jellyfin";
 }
 
 function Advanced({ label, children }: { label: string; children: ReactNode }) {
@@ -171,6 +210,7 @@ function TraktForm({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
       const result = await submitTrakt();
       if (result.user_code && result.verification_url) {
         onAuth({
+          source: "Trakt",
           link: `${result.verification_url}?code=${encodeURIComponent(result.user_code)}`,
           code: result.user_code,
           buttonLabel: "Open Trakt & Authorize",
@@ -178,7 +218,7 @@ function TraktForm({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
           intervalSeconds: result.interval ?? 5,
         });
       } else {
-        onDone();
+        onDone("Trakt");
       }
     } catch (err) {
       setError(messageOf(err));
@@ -196,7 +236,7 @@ function TraktForm({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
     setError(null);
     try {
       await submitTraktPublic(username.trim());
-      onDone();
+      onDone("Trakt");
     } catch (err) {
       setError(messageOf(err));
       setBusy(false);
@@ -250,6 +290,7 @@ function PlexPane({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
       // Best-effort auto-open; the link is shown regardless of popup blocking.
       window.open(data.authUrl, "_blank", "noopener");
       onAuth({
+        source: "Plex",
         link: data.authUrl,
         buttonLabel: "Open Plex & Authorize",
         expiresInMinutes: Math.floor((data.expiresIn ?? 1800) / 60),
@@ -271,7 +312,7 @@ function PlexPane({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
     setError(null);
     try {
       await submitPlex(form);
-      onDone();
+      onDone("Plex");
     } catch (err) {
       setError(messageOf(err));
       setBusy(false);
@@ -352,6 +393,7 @@ function JellyfinPane({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
       const data = await startJellyfinLogin(serverUrl.trim());
       const base = serverUrl.trim().replace(/\/$/, "");
       onAuth({
+        source: "Jellyfin",
         code: data.code,
         // The Quick Connect page prefills its input from `?code=`, so the user
         // only has to click Authorize (the code below is a manual fallback).
@@ -377,7 +419,7 @@ function JellyfinPane({ setError, onAuth, onDone }: Omit<SetupProps, "error">) {
     setError(null);
     try {
       await submitJellyfin(manual);
-      onDone();
+      onDone("Jellyfin");
     } catch (err) {
       setError(messageOf(err));
       setBusy(false);
@@ -476,11 +518,21 @@ function AuthScreen({ info, error }: { info: AuthInfo; error: string | null }) {
   );
 }
 
-function SuccessScreen() {
-  const [seconds, setSeconds] = useState(5);
+const FINISH_COUNTDOWN_SECONDS = 10;
+
+function SuccessScreen({
+  connected,
+  onAddAnother,
+}: {
+  connected: SourceName[];
+  onAddAnother: () => void;
+}) {
+  const [seconds, setSeconds] = useState(FINISH_COUNTDOWN_SECONDS);
   // Only count down while the tab is in focus, so a user who authorized in
   // another tab actually sees the success state before this one closes.
   const [visible, setVisible] = useState(() => document.visibilityState === "visible");
+  const [staying, setStaying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const onVisibility = () => setVisible(document.visibilityState === "visible");
@@ -488,31 +540,94 @@ function SuccessScreen() {
     return () => document.removeEventListener("visibilitychange", onVisibility);
   }, []);
 
-  const closed = useRef(false);
+  const finished = useRef(false);
+  const finish = () => {
+    // The server stops listening right after this, so fire it once and ignore
+    // the inevitable connection error from the socket closing.
+    if (finished.current) return;
+    finished.current = true;
+    void finishSetup().catch(() => {});
+    window.close();
+  };
+
   useEffect(() => {
+    if (staying) return;
     if (seconds <= 0) {
-      // window.close() is a no-op for tabs the browser opened (not script);
-      // attempt it once rather than on every later visibility toggle.
-      if (!closed.current) {
-        closed.current = true;
-        window.close();
-      }
+      finish();
       return;
     }
     if (!visible) return;
     const id = setTimeout(() => setSeconds((s) => s - 1), 1000);
     return () => clearTimeout(id);
-  }, [seconds, visible]);
+  }, [seconds, visible, staying]);
+
+  async function handleAddAnother() {
+    // Stop the countdown first: the server must stay up for the next flow.
+    setStaying(true);
+    try {
+      await continueSetup();
+      onAddAnother();
+    } catch {
+      // Setup already ended; nothing more can be connected in this run.
+      setError("Setup has already finished. Restart Discrakt to add another source.");
+      setStaying(false);
+    }
+  }
+
+  const remaining = (["Trakt", "Plex", "Jellyfin"] as const).filter(
+    (source) => !connected.includes(source),
+  );
 
   return (
-    <div className="flex flex-col items-center gap-3 text-center">
-      <h2 className="text-xl font-semibold text-emerald-500">Setup complete!</h2>
-      <p className="text-sm text-muted-foreground">Your account has been connected.</p>
+    <div className="flex flex-col items-center gap-4 text-center">
+      <h2 className="text-xl font-semibold text-emerald-500">
+        {connected.length > 1 ? "Sources connected!" : "Setup complete!"}
+      </h2>
+
+      <ul className="flex flex-col gap-1 text-sm text-muted-foreground">
+        {connected.map((source) => (
+          <li key={source} className="flex items-center justify-center gap-2">
+            <Check className="size-4 text-emerald-500" />
+            {source} connected
+          </li>
+        ))}
+      </ul>
+
+      {remaining.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Streaming from more than one? Add {formatList(remaining)} too and Discrakt shows whichever
+          one is playing.
+        </p>
+      )}
+
+      {error && <ErrorBox message={error} />}
+
+      <div className="flex w-full flex-col gap-2">
+        {remaining.length > 0 && (
+          <Button
+            variant="secondary"
+            onClick={handleAddAnother}
+            disabled={staying || error !== null}
+          >
+            {staying && <Loader2 className="animate-spin" />}
+            Add another source
+          </Button>
+        )}
+        <Button onClick={finish}>Start Discrakt</Button>
+      </div>
+
       <p className="text-xs text-muted-foreground">
-        Discrakt is now starting. This tab will close in {seconds} second{seconds === 1 ? "" : "s"}.
+        {staying
+          ? "Pick another source above."
+          : `Starting automatically in ${seconds} second${seconds === 1 ? "" : "s"}.`}
       </p>
     </div>
   );
+}
+
+function formatList(items: readonly string[]): string {
+  if (items.length <= 1) return items.join("");
+  return `${items.slice(0, -1).join(", ")} or ${items[items.length - 1]}`;
 }
 
 function messageOf(err: unknown): string {

--- a/setup-ui/src/lib/api.ts
+++ b/setup-ui/src/lib/api.ts
@@ -74,3 +74,13 @@ export async function getStatus(): Promise<SetupStatus> {
   const response = await fetch("/status");
   return (await response.json()) as SetupStatus;
 }
+
+/** Ends setup so Discrakt can start. */
+export function finishSetup(): Promise<unknown> {
+  return postJson("/finish", {});
+}
+
+/** Keeps the setup server alive so another source can be connected. */
+export function continueSetup(): Promise<unknown> {
+  return postJson("/continue", {});
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use discrakt::{
     autostart,
     discord::Discord,
     source::{
+        self,
         jellyfin::{JellyfinConfig, JellyfinSource},
         plex::{PlexConfig, PlexSource},
         trakt::TraktSource,
@@ -364,7 +365,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         e
     })?;
     // OAuth applies to the Trakt source only.
-    if cfg.source == SourceKind::Trakt {
+    if cfg.sources.contains(&SourceKind::Trakt) {
         cfg.check_oauth();
     }
 
@@ -374,7 +375,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_state_clone = Arc::clone(&app_state);
     let should_quit_clone = Arc::clone(&should_quit);
 
-    let source_kind = cfg.source;
+    let source_kinds = cfg.sources.clone();
     let trakt_client_id = cfg.trakt_client_id.clone();
     let trakt_username = cfg.trakt_username.clone();
     let trakt_access_token = cfg.trakt_access_token.clone();
@@ -392,31 +393,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn background polling thread
     let polling_handle = thread::spawn(move || {
         let mut discord = Discord::new(DEFAULT_DISCORD_APP_ID.to_string());
-        let mut source: Box<dyn Source> = match source_kind {
-            SourceKind::Trakt => {
-                let trakt = Trakt::new(trakt_client_id, trakt_username, trakt_access_token);
-                Box::new(TraktSource::new(trakt, tmdb_token))
-            }
-            SourceKind::Plex => Box::new(PlexSource::new(PlexConfig {
-                server_url: plex_server_url,
-                token: plex_token,
-                username: plex_username,
-                tmdb_token,
-                tmdb_base_url: None,
-                language: None,
-            })),
-            SourceKind::Jellyfin => Box::new(JellyfinSource::new(JellyfinConfig {
-                server_url: jellyfin_server_url,
-                access_token: jellyfin_access_token,
-                device_id: jellyfin_device_id,
-                user_id: jellyfin_user_id,
-                username: jellyfin_username,
-                tmdb_token,
-                tmdb_base_url: None,
-                language: None,
-            })),
-        };
-        source.set_language(tmdb_language);
+        // Sources are polled in configured order and the first one reporting
+        // activity wins, so a dual Plex/Jellyfin setup shows whichever is
+        // playing without running two copies of Discrakt.
+        let mut sources: Vec<Box<dyn Source>> = source_kinds
+            .iter()
+            .map(|&kind| -> Box<dyn Source> {
+                match kind {
+                    SourceKind::Trakt => {
+                        let trakt = Trakt::new(
+                            trakt_client_id.clone(),
+                            trakt_username.clone(),
+                            trakt_access_token.clone(),
+                        );
+                        Box::new(TraktSource::new(trakt, tmdb_token.clone()))
+                    }
+                    SourceKind::Plex => Box::new(PlexSource::new(PlexConfig {
+                        server_url: plex_server_url.clone(),
+                        token: plex_token.clone(),
+                        username: plex_username.clone(),
+                        tmdb_token: tmdb_token.clone(),
+                        tmdb_base_url: None,
+                        language: None,
+                    })),
+                    SourceKind::Jellyfin => Box::new(JellyfinSource::new(JellyfinConfig {
+                        server_url: jellyfin_server_url.clone(),
+                        access_token: jellyfin_access_token.clone(),
+                        device_id: jellyfin_device_id.clone(),
+                        user_id: jellyfin_user_id.clone(),
+                        username: jellyfin_username.clone(),
+                        tmdb_token: tmdb_token.clone(),
+                        tmdb_base_url: None,
+                        language: None,
+                    })),
+                }
+            })
+            .collect();
+
+        tracing::info!("Polling sources in order: {:?}", source_kinds);
+
+        for source in &mut sources {
+            source.set_language(tmdb_language.clone());
+        }
 
         discord.connect();
 
@@ -445,7 +463,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             if let Some(lang) = new_lang {
-                source.set_language(lang);
+                for source in &mut sources {
+                    source.set_language(lang.clone());
+                }
             }
 
             // Check if paused from shared state
@@ -457,8 +477,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
 
-            let watching = match source.get_watching() {
-                Some(watching) => watching,
+            let watching = match source::first_active(&mut sources) {
+                Some((index, watching)) => {
+                    tracing::debug!("Reporting activity from {:?}", source_kinds[index]);
+                    watching
+                }
                 None => {
                     tracing::debug!("Nothing is being played");
                     // Update state: nothing playing

--- a/src/setup/server.rs
+++ b/src/setup/server.rs
@@ -122,9 +122,13 @@ enum OAuthState {
     Error(String),
 }
 
-/// Grace period after OAuth success to allow browser to poll and see the success status.
-/// This should be longer than the polling interval (5 seconds) to ensure at least one poll.
-const SUCCESS_GRACE_PERIOD: Duration = Duration::from_secs(8);
+/// How long to keep the setup server alive after a source connects, when the
+/// browser never confirms it is done.
+///
+/// The wizard normally ends setup explicitly (`POST /finish`) once the user has
+/// connected everything they want, so this only applies when the browser is
+/// closed at the success screen. It must outlast the wizard's own countdown.
+const SUCCESS_GRACE_PERIOD: Duration = Duration::from_secs(25);
 
 /// Response for device code info sent to the browser.
 #[derive(Serialize, Clone)]
@@ -458,6 +462,9 @@ pub fn run_setup_server() -> Result<SetupResult, Box<dyn std::error::Error>> {
 
     // Flag to signal when setup is complete
     let setup_complete = Arc::new(AtomicBool::new(false));
+    // Set when the wizard confirms the user has connected everything they want,
+    // ending setup without waiting out the grace period.
+    let finish_now = Arc::new(AtomicBool::new(false));
     let result: Arc<Mutex<Option<SetupResult>>> = Arc::new(Mutex::new(None));
     let oauth_state: Arc<Mutex<OAuthState>> = Arc::new(Mutex::new(OAuthState::Idle));
     // Track if a polling thread is already running to prevent duplicate spawns
@@ -484,8 +491,15 @@ pub fn run_setup_server() -> Result<SetupResult, Box<dyn std::error::Error>> {
 
     // Handle requests until setup is complete and grace period has passed.
     loop {
-        // Check if setup is complete and grace period has elapsed
-        // This allows the browser to poll /status and see the success state
+        // The wizard confirmed there is nothing left to connect.
+        if finish_now.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Otherwise fall back to ending setup on our own, which covers the
+        // browser being closed at the success screen. Connecting a further
+        // source resets the state to pending, so this only fires once the user
+        // has stopped making progress.
         if setup_complete.load(Ordering::SeqCst) {
             if let Ok(state) = oauth_state.lock() {
                 if let OAuthState::Success(success_time) = *state {
@@ -996,6 +1010,44 @@ pub fn run_setup_server() -> Result<SetupResult, Box<dyn std::error::Error>> {
                         let _ = request.respond(response);
                     }
                 }
+            }
+
+            ("POST", "/finish") => {
+                // Respond before the loop notices the flag, so the wizard sees
+                // the confirmation rather than a dropped connection.
+                let response = Response::from_string(r#"{"status":"ok"}"#).with_header(
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .unwrap(),
+                );
+                let _ = request.respond(response);
+
+                tracing::info!("Setup finished by the wizard");
+                setup_complete.store(true, Ordering::SeqCst);
+                finish_now.store(true, Ordering::SeqCst);
+            }
+
+            ("POST", "/continue") => {
+                // The user wants to connect another source. Clearing the success
+                // state stops the grace-period shutdown and lets the wizard run
+                // a second flow against a server that is still listening.
+                if let Ok(mut state) = oauth_state.lock() {
+                    *state = OAuthState::Idle;
+                }
+                setup_complete.store(false, Ordering::SeqCst);
+                polling_started.store(false, Ordering::SeqCst);
+                if let Ok(mut code) = active_device_code.lock() {
+                    *code = None;
+                }
+                if let Ok(mut code) = active_jellyfin_code.lock() {
+                    *code = None;
+                }
+
+                tracing::info!("Wizard is connecting an additional source");
+                let response = Response::from_string(r#"{"status":"ok"}"#).with_header(
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .unwrap(),
+                );
+                let _ = request.respond(response);
             }
 
             ("GET", "/status") => {

--- a/src/setup/server.rs
+++ b/src/setup/server.rs
@@ -154,6 +154,49 @@ fn config_dir_path() -> Result<PathBuf, String> {
         .ok_or_else(|| "Could not determine config directory".to_string())
 }
 
+/// Adds `kind` to the `[Discrakt] source` list, keeping any sources already
+/// connected in an earlier step of the wizard.
+///
+/// The list is ordered, and earlier entries win when several sources are
+/// playing at once, so a source keeps the position it was first connected in.
+fn append_source(config: &mut Ini, kind: &str) {
+    let mut sources: Vec<String> = config
+        .get("Discrakt", "source")
+        .unwrap_or_default()
+        .split(',')
+        .map(|entry| entry.trim().to_lowercase())
+        .filter(|entry| !entry.is_empty())
+        .collect();
+
+    if !sources.iter().any(|existing| existing == kind) {
+        sources.push(kind.to_string());
+    }
+
+    config.setstr("Discrakt", "source", Some(&sources.join(", ")));
+}
+
+/// Adds `kind` to the `[Discrakt] source` list of the on-disk config.
+///
+/// Used by the flows that finish asynchronously (Trakt OAuth), where the
+/// credentials were written before the user finished authorizing.
+fn append_source_to_config_file(kind: &str) -> Result<(), String> {
+    let config_path = config_dir_path()?.join("credentials.ini");
+
+    let mut config = Ini::new_cs();
+    if config_path.exists() {
+        let _ = config.load(&config_path);
+    }
+
+    append_source(&mut config, kind);
+
+    config
+        .write(&config_path)
+        .map_err(|e| format!("Failed to write config file: {e}"))?;
+
+    set_restrictive_permissions(&config_path);
+    Ok(())
+}
+
 /// Write credentials to the config file.
 fn write_credentials(creds: &SubmittedCredentials) -> Result<PathBuf, String> {
     let config_dir = config_dir_path()?;
@@ -224,6 +267,7 @@ fn write_public_credentials(username: &str) -> Result<PathBuf, String> {
         let _ = config.load(&config_path);
     }
 
+    append_source(&mut config, "trakt");
     config.setstr("Trakt API", "traktUser", Some(username.trim()));
     config.setstr("Trakt API", "enabledOAuth", Some("false"));
     // Clear any OAuth token so the public-username endpoint is used.
@@ -261,7 +305,7 @@ fn write_jellyfin_credentials(
         let _ = config.load(&config_path);
     }
 
-    config.setstr("Discrakt", "source", Some("jellyfin"));
+    append_source(&mut config, "jellyfin");
     config.setstr("Jellyfin", "serverUrl", Some(server_url.trim()));
     config.setstr("Jellyfin", "accessToken", Some(access_token.trim()));
     config.setstr("Jellyfin", "deviceId", Some(device_id));
@@ -294,7 +338,7 @@ fn write_plex_credentials(creds: &PlexSubmitted) -> Result<PathBuf, String> {
         let _ = config.load(&config_path);
     }
 
-    config.setstr("Discrakt", "source", Some("plex"));
+    append_source(&mut config, "plex");
     config.setstr("Plex", "serverUrl", Some(creds.server_url.trim()));
     config.setstr("Plex", "token", Some(creds.token.trim()));
     config.setstr("Plex", "username", Some(creds.username.trim()));
@@ -1222,6 +1266,13 @@ fn poll_oauth_in_background(
                 // Save the tokens to config
                 save_oauth_tokens(&token);
 
+                // Registered only now: the credentials were written when the
+                // flow started, so an abandoned authorization must not leave
+                // Trakt in the source list.
+                if let Err(e) = append_source_to_config_file("trakt") {
+                    tracing::error!("Failed to register Trakt as a source: {}", e);
+                }
+
                 // Update state to success with timestamp so the server knows when
                 // to shut down (after grace period for browser to poll)
                 if let Ok(mut state) = oauth_state.lock() {
@@ -1297,6 +1348,63 @@ fn poll_oauth_in_background(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn parse_ini(contents: &str) -> Ini {
+        let mut config = Ini::new_cs();
+        config.read(contents.to_string()).expect("valid ini");
+        config
+    }
+
+    #[test]
+    fn test_append_source_sets_the_first_source() {
+        let mut config = parse_ini("");
+        append_source(&mut config, "plex");
+        assert_eq!(config.get("Discrakt", "source").as_deref(), Some("plex"));
+    }
+
+    #[test]
+    fn test_append_source_keeps_a_previously_connected_source() {
+        // Connecting a second source in the wizard must not drop the first.
+        let mut config = parse_ini("[Discrakt]\nsource=plex\n");
+        append_source(&mut config, "jellyfin");
+        assert_eq!(
+            config.get("Discrakt", "source").as_deref(),
+            Some("plex, jellyfin")
+        );
+    }
+
+    #[test]
+    fn test_append_source_preserves_connection_order() {
+        let mut config = parse_ini("");
+        append_source(&mut config, "jellyfin");
+        append_source(&mut config, "trakt");
+        append_source(&mut config, "plex");
+        assert_eq!(
+            config.get("Discrakt", "source").as_deref(),
+            Some("jellyfin, trakt, plex")
+        );
+    }
+
+    #[test]
+    fn test_append_source_is_idempotent() {
+        // Reconnecting a source (e.g. re-running its login) must not list it twice.
+        let mut config = parse_ini("[Discrakt]\nsource=plex, jellyfin\n");
+        append_source(&mut config, "plex");
+        assert_eq!(
+            config.get("Discrakt", "source").as_deref(),
+            Some("plex, jellyfin")
+        );
+    }
+
+    #[test]
+    fn test_append_source_normalizes_an_existing_list() {
+        let mut config = parse_ini("[Discrakt]\nsource=  PLEX ,, jellyfin \n");
+        append_source(&mut config, "trakt");
+        assert_eq!(
+            config.get("Discrakt", "source").as_deref(),
+            Some("plex, jellyfin, trakt")
+        );
+    }
 
     #[test]
     fn test_parse_json_body() {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -60,3 +60,15 @@ pub trait Source: Send {
     /// Updates the preferred language for localized titles. No-op by default.
     fn set_language(&mut self, _language: String) {}
 }
+
+/// Polls `sources` in order and returns the first reported activity, along with
+/// the index of the source that reported it.
+///
+/// Polling stops at the first hit, so when several sources are configured the
+/// earlier ones take precedence and the later ones are not contacted at all.
+pub fn first_active(sources: &mut [Box<dyn Source>]) -> Option<(usize, Watching)> {
+    sources
+        .iter_mut()
+        .enumerate()
+        .find_map(|(index, source)| source.get_watching().map(|watching| (index, watching)))
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -175,8 +175,9 @@ pub enum SourceKind {
 }
 
 pub struct Env {
-    /// The selected tracking source.
-    pub source: SourceKind,
+    /// The selected tracking sources, in priority order. The first one
+    /// reporting activity is the one shown on Discord.
+    pub sources: Vec<SourceKind>,
     pub trakt_username: String,
     pub trakt_client_id: String,
     pub trakt_oauth_enabled: bool,
@@ -664,28 +665,68 @@ fn jellyfin_configured(config: &Ini) -> bool {
             .is_some_and(|s| !s.is_empty())
 }
 
-/// Determines the active source, honoring an explicit `[Discrakt] source`
-/// override and otherwise falling back to whichever source is configured.
-fn determine_source(
+/// Parses the `[Discrakt] source` value into an ordered, de-duplicated list.
+///
+/// The value is a comma-separated list (`source = plex, jellyfin`); a single
+/// name is just a one-element list. Unrecognized names are ignored, so a value
+/// that names nothing valid yields an empty list.
+fn parse_source_list(value: &str) -> Vec<SourceKind> {
+    let mut sources = Vec::new();
+
+    for entry in value.split(',') {
+        let kind = match entry.trim().to_lowercase().as_str() {
+            "plex" => SourceKind::Plex,
+            "jellyfin" => SourceKind::Jellyfin,
+            "trakt" => SourceKind::Trakt,
+            "" => continue,
+            other => {
+                tracing::warn!("Ignoring unknown source '{}' in [Discrakt] source", other);
+                continue;
+            }
+        };
+
+        if !sources.contains(&kind) {
+            sources.push(kind);
+        }
+    }
+
+    sources
+}
+
+/// Determines the active sources in priority order, honoring an explicit
+/// `[Discrakt] source` override and otherwise falling back to whichever source
+/// is configured.
+///
+/// An explicit list is taken at face value, including sources that have no
+/// credentials yet, so an intentional choice is never silently overridden.
+/// Without a usable explicit value, exactly one source is auto-detected.
+fn determine_sources(
     config: &Ini,
     trakt_configured: bool,
     plex_configured: bool,
     jellyfin_configured: bool,
-) -> SourceKind {
-    match config
+) -> Vec<SourceKind> {
+    let explicit = config
         .get("Discrakt", "source")
-        .map(|s| s.trim().to_lowercase())
-        .as_deref()
-    {
-        Some("plex") => SourceKind::Plex,
-        Some("jellyfin") => SourceKind::Jellyfin,
-        Some("trakt") => SourceKind::Trakt,
-        // No explicit choice: prefer Trakt, then Plex, then Jellyfin.
-        _ if trakt_configured => SourceKind::Trakt,
-        _ if plex_configured => SourceKind::Plex,
-        _ if jellyfin_configured => SourceKind::Jellyfin,
-        _ => SourceKind::Trakt,
+        .map(|value| parse_source_list(&value))
+        .unwrap_or_default();
+
+    if !explicit.is_empty() {
+        return explicit;
     }
+
+    // No explicit choice: prefer Trakt, then Plex, then Jellyfin.
+    let detected = if trakt_configured {
+        SourceKind::Trakt
+    } else if plex_configured {
+        SourceKind::Plex
+    } else if jellyfin_configured {
+        SourceKind::Jellyfin
+    } else {
+        SourceKind::Trakt
+    };
+
+    vec![detected]
 }
 
 /// Load configuration from the credentials file.
@@ -752,7 +793,7 @@ pub fn load_config() -> Result<Env, String> {
     let trakt_has_oauth = config
         .get("Trakt API", "OAuthAccessToken")
         .is_some_and(|s| !s.is_empty());
-    let source = determine_source(
+    let sources = determine_sources(
         &config,
         !trakt_username.is_empty() || trakt_has_oauth,
         !plex_server_url.is_empty() && !plex_token.is_empty(),
@@ -760,7 +801,7 @@ pub fn load_config() -> Result<Env, String> {
     );
 
     Ok(Env {
-        source,
+        sources,
         trakt_username,
         trakt_client_id,
         trakt_oauth_enabled: config
@@ -945,7 +986,7 @@ pub fn save_language_preference(language: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{determine_source, read_plex_config, SourceKind};
+    use super::{determine_sources, read_plex_config, SourceKind};
     use configparser::ini::Ini;
 
     fn parse(contents: &str) -> Ini {
@@ -955,51 +996,117 @@ mod tests {
     }
 
     #[test]
-    fn determine_source_defaults_to_trakt() {
+    fn determine_sources_defaults_to_trakt() {
         let config = parse("[Trakt API]\ntraktUser=alice\n");
         assert_eq!(
-            determine_source(&config, true, false, false),
-            SourceKind::Trakt
+            determine_sources(&config, true, false, false),
+            vec![SourceKind::Trakt]
         );
     }
 
     #[test]
-    fn determine_source_uses_plex_when_only_plex_configured() {
+    fn determine_sources_uses_plex_when_only_plex_configured() {
         let config = parse("[Plex]\nserverUrl=http://host:32400\ntoken=abc\n");
         assert_eq!(
-            determine_source(&config, false, true, false),
-            SourceKind::Plex
+            determine_sources(&config, false, true, false),
+            vec![SourceKind::Plex]
         );
     }
 
     #[test]
-    fn determine_source_uses_jellyfin_when_only_jellyfin_configured() {
+    fn determine_sources_uses_jellyfin_when_only_jellyfin_configured() {
         let config = parse("[Jellyfin]\nserverUrl=http://host:8096\naccessToken=abc\n");
         assert_eq!(
-            determine_source(&config, false, false, true),
-            SourceKind::Jellyfin
+            determine_sources(&config, false, false, true),
+            vec![SourceKind::Jellyfin]
         );
     }
 
     #[test]
-    fn determine_source_honors_explicit_override() {
+    fn determine_sources_auto_detects_only_one_source() {
+        let config = parse("[Trakt API]\ntraktUser=alice\n[Plex]\nserverUrl=http://h\ntoken=t\n");
+        assert_eq!(
+            determine_sources(&config, true, true, true),
+            vec![SourceKind::Trakt]
+        );
+    }
+
+    #[test]
+    fn determine_sources_honors_explicit_override() {
         let config = parse("[Discrakt]\nsource=plex\n[Trakt API]\ntraktUser=alice\n");
         // Both configured, but the explicit override wins.
         assert_eq!(
-            determine_source(&config, true, true, false),
-            SourceKind::Plex
+            determine_sources(&config, true, true, false),
+            vec![SourceKind::Plex]
         );
 
         let config = parse("[Discrakt]\nsource=jellyfin\n[Trakt API]\ntraktUser=alice\n");
         assert_eq!(
-            determine_source(&config, true, false, true),
-            SourceKind::Jellyfin
+            determine_sources(&config, true, false, true),
+            vec![SourceKind::Jellyfin]
         );
 
         let config = parse("[Discrakt]\nsource=trakt\n[Plex]\nserverUrl=http://h\ntoken=t\n");
         assert_eq!(
-            determine_source(&config, false, true, false),
-            SourceKind::Trakt
+            determine_sources(&config, false, true, false),
+            vec![SourceKind::Trakt]
+        );
+    }
+
+    #[test]
+    fn determine_sources_reads_a_comma_separated_list_in_order() {
+        let config = parse("[Discrakt]\nsource=plex, jellyfin\n");
+        assert_eq!(
+            determine_sources(&config, false, true, true),
+            vec![SourceKind::Plex, SourceKind::Jellyfin]
+        );
+
+        let config = parse("[Discrakt]\nsource=jellyfin,plex\n");
+        assert_eq!(
+            determine_sources(&config, false, true, true),
+            vec![SourceKind::Jellyfin, SourceKind::Plex]
+        );
+    }
+
+    #[test]
+    fn determine_sources_normalizes_case_whitespace_and_duplicates() {
+        let config = parse("[Discrakt]\nsource=  PLEX , plex,\tJellyFin ,,\n");
+        assert_eq!(
+            determine_sources(&config, false, true, true),
+            vec![SourceKind::Plex, SourceKind::Jellyfin]
+        );
+    }
+
+    #[test]
+    fn determine_sources_skips_unknown_entries_in_a_list() {
+        let config = parse("[Discrakt]\nsource=emby, jellyfin\n");
+        assert_eq!(
+            determine_sources(&config, false, false, true),
+            vec![SourceKind::Jellyfin]
+        );
+    }
+
+    #[test]
+    fn determine_sources_falls_back_when_no_entry_is_recognized() {
+        let config = parse("[Discrakt]\nsource=emby\n[Plex]\nserverUrl=http://h\ntoken=t\n");
+        assert_eq!(
+            determine_sources(&config, false, true, false),
+            vec![SourceKind::Plex]
+        );
+
+        let config = parse("[Discrakt]\nsource=\n[Plex]\nserverUrl=http://h\ntoken=t\n");
+        assert_eq!(
+            determine_sources(&config, false, true, false),
+            vec![SourceKind::Plex]
+        );
+    }
+
+    #[test]
+    fn determine_sources_keeps_explicit_entries_that_are_not_configured_yet() {
+        let config = parse("[Discrakt]\nsource=plex, jellyfin\n");
+        assert_eq!(
+            determine_sources(&config, false, true, false),
+            vec![SourceKind::Plex, SourceKind::Jellyfin]
         );
     }
 

--- a/tests/source_tests.rs
+++ b/tests/source_tests.rs
@@ -8,8 +8,10 @@ mod common;
 
 use discrakt::source::plex::{PlexConfig, PlexSource};
 use discrakt::source::trakt::TraktSource;
-use discrakt::source::{MediaKind, Source};
+use discrakt::source::{first_active, MediaKind, Source, Watching};
 use discrakt::trakt::{Trakt, TraktConfig};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 fn trakt_source(server_url: String) -> TraktSource {
     let trakt = Trakt::with_config(TraktConfig {
@@ -820,4 +822,168 @@ fn test_jellyfin_source_episode_without_series_tmdb_falls_back_to_jellyfin_title
     assert_eq!(result.episode_title.as_deref(), Some("Felina"));
     assert_eq!(result.ids.tmdb, None);
     assert_eq!(result.poster_url, None);
+}
+
+// Multi-source selection: `first_active` polls in configured order and the
+// first source reporting activity wins, so a dual Plex/Jellyfin setup shows
+// whichever one is streaming.
+
+/// A `Source` that reports a fixed result and counts how often it was polled.
+struct StubSource {
+    watching: Option<Watching>,
+    polls: Arc<AtomicUsize>,
+}
+
+impl StubSource {
+    fn new(watching: Option<Watching>) -> (Self, Arc<AtomicUsize>) {
+        let polls = Arc::new(AtomicUsize::new(0));
+        (
+            StubSource {
+                watching,
+                polls: Arc::clone(&polls),
+            },
+            polls,
+        )
+    }
+}
+
+impl Source for StubSource {
+    fn get_watching(&mut self) -> Option<Watching> {
+        self.polls.fetch_add(1, Ordering::Relaxed);
+        self.watching.clone()
+    }
+}
+
+#[test]
+fn test_first_active_prefers_the_earlier_source_and_skips_the_rest() {
+    let (first, first_polls) = StubSource::new(Some(common::watching::movie_watching()));
+    let (second, second_polls) = StubSource::new(Some(common::watching::episode_watching()));
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(first), Box::new(second)];
+
+    let (index, watching) = first_active(&mut sources).expect("first source is playing");
+
+    assert_eq!(index, 0);
+    assert_eq!(watching.title, "Inception");
+    assert_eq!(first_polls.load(Ordering::Relaxed), 1);
+    // The winner short-circuits, so the later source is never contacted.
+    assert_eq!(second_polls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn test_first_active_falls_through_to_a_later_source() {
+    let (first, first_polls) = StubSource::new(None);
+    let (second, second_polls) = StubSource::new(Some(common::watching::episode_watching()));
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(first), Box::new(second)];
+
+    let (index, watching) = first_active(&mut sources).expect("second source is playing");
+
+    assert_eq!(index, 1);
+    assert_eq!(watching.title, "Breaking Bad");
+    assert_eq!(first_polls.load(Ordering::Relaxed), 1);
+    assert_eq!(second_polls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn test_first_active_returns_none_when_no_source_is_playing() {
+    let (first, _) = StubSource::new(None);
+    let (second, second_polls) = StubSource::new(None);
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(first), Box::new(second)];
+
+    assert!(first_active(&mut sources).is_none());
+    // Every source is tried before giving up.
+    assert_eq!(second_polls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn test_first_active_handles_a_single_source() {
+    let (only, _) = StubSource::new(Some(common::watching::movie_watching()));
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(only)];
+
+    let (index, watching) = first_active(&mut sources).expect("the only source is playing");
+
+    assert_eq!(index, 0);
+    assert_eq!(watching.title, "Inception");
+}
+
+/// A Jellyfin movie session with no TMDB ids, so no artwork lookups are needed.
+const JELLYFIN_PLAIN_MOVIE: &str = r#"[{
+    "UserId": "u1", "UserName": "alice",
+    "NowPlayingItem": {
+        "Name": "Arrival", "Type": "Movie", "ProductionYear": 2016,
+        "RunTimeTicks": 68400000000
+    },
+    "PlayState": {"PositionTicks": 6000000000, "IsPaused": false}
+}]"#;
+
+/// A Plex movie session with no TMDB ids, so no artwork lookups are needed.
+const PLEX_PLAIN_MOVIE: &str = r#"{"MediaContainer": {"size": 1, "Metadata": [{
+    "type": "movie", "title": "Dune", "year": 2021, "ratingKey": "1",
+    "duration": 9360000, "viewOffset": 600000,
+    "User": {"title": "alice"},
+    "Player": {"state": "playing"}
+}]}}"#;
+
+#[test]
+fn test_dual_plex_and_jellyfin_falls_through_to_the_playing_server() {
+    // A real dual setup: Plex is idle, Jellyfin is streaming, so Jellyfin shows.
+    let mut plex_server = mockito::Server::new();
+    let mut jellyfin_server = mockito::Server::new();
+    let plex = plex_source(
+        plex_server.url(),
+        r#"{"MediaContainer": {"size": 0}}"#,
+        &mut plex_server,
+    );
+    let jellyfin = jellyfin_source(
+        jellyfin_server.url(),
+        JELLYFIN_PLAIN_MOVIE,
+        &mut jellyfin_server,
+    );
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(plex), Box::new(jellyfin)];
+
+    let (index, watching) = first_active(&mut sources).expect("Jellyfin is playing");
+
+    assert_eq!(index, 1);
+    assert_eq!(watching.kind, MediaKind::Movie);
+    assert_eq!(watching.title, "Arrival");
+}
+
+#[test]
+fn test_dual_plex_and_jellyfin_prefers_plex_when_both_are_playing() {
+    // Both streaming at once: the first listed source wins and the second
+    // server is never contacted.
+    let mut plex_server = mockito::Server::new();
+    let mut jellyfin_server = mockito::Server::new();
+    // The session carries no Guid, so Plex resolves ids via a metadata lookup.
+    plex_server
+        .mock("GET", "/library/metadata/1")
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"MediaContainer":{"Metadata":[{"Guid":[]}]}}"#)
+        .create();
+    let plex = plex_source(plex_server.url(), PLEX_PLAIN_MOVIE, &mut plex_server);
+    let jellyfin_sessions = jellyfin_server
+        .mock("GET", "/Sessions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(JELLYFIN_PLAIN_MOVIE)
+        .expect(0)
+        .create();
+    let jellyfin = JellyfinSource::new(JellyfinConfig {
+        server_url: jellyfin_server.url(),
+        access_token: "tok".to_string(),
+        device_id: "dev".to_string(),
+        user_id: "u1".to_string(),
+        username: String::new(),
+        tmdb_token: "test_tmdb_token".to_string(),
+        tmdb_base_url: Some(jellyfin_server.url()),
+        language: None,
+    });
+    let mut sources: Vec<Box<dyn Source>> = vec![Box::new(plex), Box::new(jellyfin)];
+
+    let (index, watching) = first_active(&mut sources).expect("Plex is playing");
+
+    assert_eq!(index, 0);
+    assert_eq!(watching.title, "Dune");
+    jellyfin_sessions.assert();
 }


### PR DESCRIPTION
## Summary

Discrakt could only poll one source at a time, so a dual Plex/Jellyfin setup meant running a Plex-only and a Jellyfin-only app side by side. `[Discrakt] source` now accepts a comma-separated list, and the setup wizard can connect several sources in one run.

```ini
[Discrakt]
source = plex, jellyfin
```

Sources are polled in the order listed and the first one playing wins, so if both are streaming at once, Plex shows. Polling short-circuits at the first hit, so later sources are only contacted when the earlier ones are idle.

## How it works

The `Source` trait already unified all three backends behind `get_watching() -> Option<Watching>`, so the core is a `find_map` over a `Vec<Box<dyn Source>>` (`source::first_active`) instead of a single boxed source.

Two existing behaviours are deliberately preserved:

- An explicit list is taken at face value, including sources with no credentials yet. This matches how a single explicit `source = trakt` already won even when Trakt wasn't configured, so an intentional choice is never silently overridden.
- Auto-detection (no `source` key) still resolves to exactly one source. Returning everything configured would have silently enabled dual reporting for existing users who never asked for it, and Trakt alongside Plex/Jellyfin usually double-reports.

In the wizard, source writers now append to the list rather than overwrite it. Trakt registers itself too (it previously relied on being the fallback default); the OAuth path appends only once authorization succeeds, since credentials are written when that flow *starts* and an abandoned authorization must not leave Trakt in the list.

Because the server no longer stops the moment a source connects, `POST /finish` ends setup explicitly and `POST /continue` keeps it alive for another flow. `SUCCESS_GRACE_PERIOD` went 8s to 25s as the fallback for a browser closed at the success screen.

## Testing

- 10 unit tests for list parsing: order, case, whitespace, duplicates, unknown entries, and the fallbacks.
- 5 unit tests for the wizard's source-list append: first write, preserving a prior source, ordering, idempotence, normalizing a messy list.
- 6 integration tests for selection. Four use stub sources for precedence and short-circuiting; two drive real `PlexSource` + `JellyfinSource` against separate mock HTTP servers, including asserting Jellyfin's `/Sessions` is never contacted when Plex wins.
- Wizard exercised end to end in a real browser: connected Jellyfin, clicked **Add another source**, connected Plex, and confirmed the config ended as `source = jellyfin, plex` with the app logging `Polling sources in order: [Jellyfin, Plex]`.
- Confirmed the browser's countdown posts `/finish` on its own, and that a closed browser still self-ends setup at ~26s rather than hanging.

## Notes

- Listing a source you have not configured still gets polled and retried every cycle, delaying the sources behind it. Documented in the README.
- `mise.toml` moves nub from a 0.4.11 pin to `latest` (0.7.5). Verified `--frozen-lockfile` still holds with the lockfile byte-identical, and the built assets have the same content hashes as before.

Closes #283
